### PR TITLE
Fix usePoolShare hook

### DIFF
--- a/apps/liquiditymining/src/ui/liquiditymining/hooks/usePoolShare.ts
+++ b/apps/liquiditymining/src/ui/liquiditymining/hooks/usePoolShare.ts
@@ -22,11 +22,9 @@ export function usePoolShare(
   );
 
   const { data: userInfo } = useUserInfo(account, poolAddress);
-  const depositedBalance = userInfo?.amount || "0.0";
+  const depositedBalance = userInfo?.amount || 0;
 
-  if (!depositedBalance || !totalPoolShare) {
-    return "0.00%";
-  }
+  const share = (+depositedBalance / +(totalPoolShare || 0)) * 100;
 
-  return `${((+depositedBalance / +totalPoolShare) * 100).toFixed(2)}%`;
+  return `${(share || 0).toFixed(2)}%`;
 }


### PR DESCRIPTION
In cases where both the `depositedBalance` and `totalPoolShare` were `0`, it resulted in a `NaN` value (from dividing `0` by `0`). This does the calc before formatting and uses `0` as a fallback incase the `share` ends up being `NaN`.

I also removed the early return to reduce formatting logic (2 decimal places and suffixed with `%`) to a single source of truth.