### PR TITLE
Fix hover state when only one inputToken

### DIFF
--- a/apps/elf-frontend/src/ui/fixedrates/BuyFixedRatesView/BuyFixedRatesInputSelect.tsx
+++ b/apps/elf-frontend/src/ui/fixedrates/BuyFixedRatesView/BuyFixedRatesInputSelect.tsx
@@ -39,9 +39,6 @@ export function BuyFixedRatesInputSelect({
   const height = isLargeScreen ? 40 : 30;
   const width = height;
 
-  console.log("DISABLE?: ", inputTokens.length === 1);
-  console.log(inputTokens);
-
   return (
     <div className={tw("flex", "flex-col", "space-y-3")}>
       <span className={tw("text-base", "text-left")}>{t`Choose Token`}</span>


### PR DESCRIPTION
No longer shows pointer cursor when hovering over the 'Choose Token' input for terms with only one inputToken. 

For some reason setting `disabled=true` on the button, child of `TokenInfoSelect`, still sets the cursor to pointer even though the button is disabled. Did a work around for this and noted in the comments above the workaround