### PR TITLE
Fix back arrow contrast issue in light mode

### DIFF
--- a/apps/elf-frontend/src/ui/fixedrates/BuyFixedRatesView/BuyFixedRatesViewWithZap.tsx
+++ b/apps/elf-frontend/src/ui/fixedrates/BuyFixedRatesView/BuyFixedRatesViewWithZap.tsx
@@ -59,8 +59,6 @@ export function BuyFixedRatesViewWithZap({
       ? BuyFixedRatesKind.Swap
       : BuyFixedRatesKind.Zap;
 
-  const color = isDarkMode ? "bg-white" : "bg-blue";
-
   return (
     <Fragment>
       <Title


### PR DESCRIPTION
Fixed back arrow and pipe divider remaining white when in light mode 

<img width="346" alt="Screen Shot 2022-04-29 at 6 42 30 PM" src="https://user-images.githubusercontent.com/19617238/166085771-3cc291dc-fd55-43c0-b607-0e071a3ee80a.png">
<img width="346" alt="Screen Shot 2022-04-29 at 6 42 23 PM" src="https://user-images.githubusercontent.com/19617238/166085774-8c1e60fb-5701-4630-9117-5f11a66406c0.png">
