### PR TITLE
Fix excess decimals

### DIFF
--- a/apps/elf-council-frontend/src/ui/gsc/ThresholdProgressBar.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/ThresholdProgressBar.tsx
@@ -28,12 +28,12 @@ export function ThresholdProgressBar({
         <span className="text-lg">{t`GSC Eligibility`}</span>
       </div>
       <ProgressBar progress={+votingPower / +threshold} />
-      <div>
-        <span className="text-sm">
+      <div className="text-sm leading-5">
+        <span>
           {`${votingPercent}%`} ({formatBalance2(votingPower, 4)} /{" "}
           {commify(threshold)} ){" "}
         </span>
-        <span className="text-sm">{t`required to join GSC`}</span>
+        <span className="whitespace-nowrap">{t`required to join GSC`}</span>
       </div>
     </div>
   );

--- a/apps/elf-council-frontend/src/ui/overview/PortfolioCard.tsx
+++ b/apps/elf-council-frontend/src/ui/overview/PortfolioCard.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement } from "react";
 
 import { Provider } from "@ethersproject/providers";
 import { Signer } from "ethers";
-import { commify, formatEther, parseEther } from "ethers/lib/utils";
 import { t } from "ttag";
 
 import { getEtherscanAddress } from "src/elf-etherscan/domain";
@@ -16,14 +15,12 @@ import ExternalLink from "src/ui/base/ExternalLink/ExternalLink";
 import { useDeposited } from "src/ui/base/lockingVault/useDeposited";
 import { useFormattedWalletAddress } from "src/ui/ethereum/useFormattedWalletAddress";
 import { JoinGSCButton, LeaveGSCButton } from "src/ui/gsc/GSCButtons";
-import { useGSCVotePowerThreshold } from "src/ui/gsc/useGSCVotePowerThreshold";
-import { useIsGSCMember } from "src/ui/gsc/useIsGSCMember";
 import { TooltipDefinition } from "src/ui/voting/tooltipDefinitions";
 import { useVotingPowerForAccountAtLatestBlock } from "src/ui/voting/useVotingPowerForAccount";
 import { useFeatureFlag } from "src/elf/featureFlag/useFeatureFlag";
 import { FeatureFlag } from "src/elf/featureFlag/featureFlag";
-import { ProgressBar } from "src/ui/base/ProgressBar/ProgressBar";
 import { useGSCStatus, EligibilityState } from "src/ui/gsc/useGSCStatus";
+import { ThresholdProgressBar } from "src/ui/gsc/ThresholdProgressBar";
 
 interface PortfolioCardProps {
   account: string | undefined | null;
@@ -109,31 +106,5 @@ export function PortfolioCard(props: PortfolioCardProps): ReactElement {
         )}
       </div>
     </Card>
-  );
-}
-
-interface ThresholdProgressBarProps {
-  account: string | null | undefined;
-}
-function ThresholdProgressBar(props: ThresholdProgressBarProps) {
-  const { account } = props;
-  const { data: thresholdBN } = useGSCVotePowerThreshold();
-  const threshold = formatEther(thresholdBN || 0);
-  const votingPower = useVotingPowerForAccountAtLatestBlock(account);
-  const votingPercent = Math.floor((+votingPower / +threshold) * 100);
-
-  return (
-    <div className="mr-3 w-full space-y-1 text-white">
-      <div>
-        <span className="text-lg">{t`GSC Eligibility`}</span>
-      </div>
-      <ProgressBar progress={+votingPower / +threshold} />
-      <div>
-        <span className="text-sm">
-          {`${votingPercent}%`} ({commify(votingPower)} / {commify(threshold)} ){" "}
-        </span>
-        <span className="text-sm">{t`required to join GSC`}</span>
-      </div>
-    </div>
   );
 }


### PR DESCRIPTION
Refactored `PortfolioCard` to use the already implemented `ThresholdProgressBar` which fixed the comma issue, also touched up the line-height and made it so it doesn't break the words--looked awkward with orphaned words.

Current:
<img width="500" alt="Screen Shot 2022-05-12 at 3 34 28 PM" src="https://user-images.githubusercontent.com/19617238/168178468-67e0564f-4389-4f36-b12c-622056fdbc4f.png">

Proposed:
<img width="506" alt="Screen Shot 2022-05-12 at 3 34 11 PM" src="https://user-images.githubusercontent.com/19617238/168178474-ee9b1cbb-d18d-49dd-bf77-0b2bd2834b25.png">
 
