### PR TITLE
Misc GSC UI changes part 1

### DIFF
--- a/apps/elf-council-frontend/src/ui/base/Button/styles.ts
+++ b/apps/elf-council-frontend/src/ui/base/Button/styles.ts
@@ -140,7 +140,7 @@ function getBackground(
 function getTextColor(variant: ButtonVariant): string {
   switch (variant) {
     case ButtonVariant.DANGER:
-      return classNames("text-deepRed");
+      return classNames("text-deepRed", "hover:text-statusRed");
     case ButtonVariant.PRIMARY:
     case ButtonVariant.OUTLINE_WHITE:
     case ButtonVariant.GRADIENT:

--- a/apps/elf-council-frontend/src/ui/base/Button/styles.ts
+++ b/apps/elf-council-frontend/src/ui/base/Button/styles.ts
@@ -93,7 +93,7 @@ function getBackground(
       return classNames("bg-hackerSky", "hover:bg-hackerSky-dark");
 
     case ButtonVariant.DANGER:
-      return classNames("bg-red-500", "hover:bg-red-800");
+      return classNames("bg-statusRed", "hover:bg-red-800");
 
     case ButtonVariant.GRADIENT:
       return classNames(
@@ -139,13 +139,13 @@ function getBackground(
 
 function getTextColor(variant: ButtonVariant): string {
   switch (variant) {
-    case ButtonVariant.PRIMARY:
     case ButtonVariant.DANGER:
+      return classNames("text-deepRed");
+    case ButtonVariant.PRIMARY:
     case ButtonVariant.OUTLINE_WHITE:
     case ButtonVariant.GRADIENT:
     case ButtonVariant.REWARD:
       return classNames("text-white");
-
     case ButtonVariant.SECONDARY:
     case ButtonVariant.MINIMAL:
     case ButtonVariant.OUTLINE_BLUE:

--- a/apps/elf-council-frontend/src/ui/base/ProgressBar/ProgressBar.tsx
+++ b/apps/elf-council-frontend/src/ui/base/ProgressBar/ProgressBar.tsx
@@ -4,9 +4,10 @@ interface ProgressBarProps {
   // value between 0 and 1
   progress: number;
   enableBar?: boolean;
+  color?: string;
 }
 export function ProgressBar(props: ProgressBarProps): ReactElement {
-  const { progress, enableBar } = props;
+  const { progress, enableBar, color } = props;
 
   const percentComplete = Math.min(Math.floor(progress * 100), 100);
 
@@ -16,10 +17,12 @@ export function ProgressBar(props: ProgressBarProps): ReactElement {
   }
 
   return (
-    <div className="relative h-2 w-full rounded-full bg-sky-300 bg-opacity-50 ">
+    <div className="relative h-3 w-full rounded-full bg-sky-300 bg-opacity-50 ">
       <div
         style={{ width: `${percentComplete}%` }}
-        className="h-full rounded-full bg-sky-100 text-center text-xs text-white"
+        className={`h-full rounded-full text-center text-xs text-white ${
+          color ?? "bg-sky-300"
+        }`}
       ></div>
       {!!barPosition && enableBar && (
         <div

--- a/apps/elf-council-frontend/src/ui/gsc/ChangeDelegationButton.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/ChangeDelegationButton.tsx
@@ -12,6 +12,7 @@ interface ChangeDelegateButtonProps {
   account: string | null | undefined;
   isLoading: boolean;
   isCurrentDelegate: boolean;
+  disabled?: boolean;
 }
 
 export function ChangeDelegateButton({
@@ -19,6 +20,7 @@ export function ChangeDelegateButton({
   account,
   isLoading,
   isCurrentDelegate,
+  disabled,
 }: ChangeDelegateButtonProps): ReactElement {
   if (isCurrentDelegate) {
     // !font-bold because Tag has font-medium which has cascade priority over font-bold
@@ -36,7 +38,7 @@ export function ChangeDelegateButton({
     <Button
       onClick={onDelegationClick}
       variant={ButtonVariant.GRADIENT}
-      disabled={!account || isLoading}
+      disabled={!account || isLoading || disabled}
       className="w-full justify-center"
       loading={isLoading}
     >

--- a/apps/elf-council-frontend/src/ui/gsc/GSCButtons.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCButtons.tsx
@@ -63,7 +63,9 @@ export function JoinGSCButton({
         disabled={disabled}
         loading={isLoading}
         onClick={() => setDialogOpen(true)}
-      >{t`${isGSC ? "Joined" : "Join"}`}</Button>
+      >
+        {isGSC ? t`Joined` : t`Join`}
+      </Button>
 
       <Dialog isOpen={dialogOpen} onClose={() => setDialogOpen(false)}>
         <div>

--- a/apps/elf-council-frontend/src/ui/gsc/GSCButtons.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCButtons.tsx
@@ -17,12 +17,14 @@ interface GSCButtonProps {
   account: string | null | undefined;
   signer: Signer | undefined;
   disabled?: boolean;
+  isGSC?: boolean;
 }
 
 export function JoinGSCButton({
   account,
   signer,
   disabled,
+  isGSC,
 }: GSCButtonProps): ReactElement {
   const toastIdRef = useRef<string>();
   const { handleJoin, isLoading } = useJoinGSC(account, signer, {
@@ -61,7 +63,7 @@ export function JoinGSCButton({
         disabled={disabled}
         loading={isLoading}
         onClick={() => setDialogOpen(true)}
-      >{t`Join`}</Button>
+      >{t`${isGSC ? "Joined" : "Join"}`}</Button>
 
       <Dialog isOpen={dialogOpen} onClose={() => setDialogOpen(false)}>
         <div>

--- a/apps/elf-council-frontend/src/ui/gsc/GSCHistory.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCHistory.tsx
@@ -9,33 +9,35 @@ interface GSCHistoryProps {
   status: EligibilityState;
 }
 
-export const GSCHistory = ({ status }: GSCHistoryProps): ReactElement => {
+function getGSCStatusText(status: EligibilityState): ReactElement {
   if (status === EligibilityState.Eligible) {
     return (
-      <>
-        <span className="text-xl text-white">{t`GSC History`}</span>
-        <span className="w-max text-sm text-white">{t`Currently eligible to join the GSC!`}</span>
-      </>
+      <span className="w-max text-sm text-white">{t`Currently eligible to join the GSC!`}</span>
     );
   }
 
   if (status === EligibilityState.Current) {
     return (
-      <>
-        <span className="text-xl text-white">{t`GSC History`}</span>
-        <span className="w-max text-sm text-white">{t`Currently in the GSC!`}</span>
-      </>
+      <span className="w-max text-sm text-white">{t`Currently in the GSC!`}</span>
     );
   }
 
   if (status === EligibilityState.Approaching) {
     return (
       <>
-        <span className="text-xl text-white">{t`GSC History`}</span>
-        <span className="w-max text-sm text-white">{t`You are currently approaching eligibility for the GSC`}</span>
-        <span className="w-[400px] text-sm text-white">{t`To learn more about our GSC program, its role within the Element DAO’s
-        Governance, and how it affects your experience as a member read more
-        here.`}</span>
+        <span className="mt-1 flex items-center">
+          <span className="mr-1 w-max text-sm text-white underline">
+            {t`Membership Warning`}
+          </span>
+          <Tooltip
+            className="text-white"
+            content={t`To learn more about our GSC program, its role within the Element DAO’s
+            Governance, and how it affects your experience as a member read more
+            here.`}
+          >
+            <InformationCircleIcon className="h-4 cursor-help" />
+          </Tooltip>
+        </span>
       </>
     );
   }
@@ -43,14 +45,15 @@ export const GSCHistory = ({ status }: GSCHistoryProps): ReactElement => {
   if (status === EligibilityState.Expiring) {
     return (
       <>
-        <span className="text-xl text-white">{t`GSC History`}</span>
         <span className="mt-1 flex items-center">
           <span className="mr-1 w-max text-sm text-white underline">
             {t`Membership Warning`}
           </span>
           <Tooltip
             className="text-white"
-            content={t`Membership warning placeholder.`}
+            content={t`You’re currently under the 110,000 ELFI delegation threshold for the
+            Governance Steering Council (GSC). Please be advised this means that
+            community members are permitted to remove you from the Council.`}
           >
             <InformationCircleIcon className="h-4 cursor-help" />
           </Tooltip>
@@ -62,26 +65,36 @@ export const GSCHistory = ({ status }: GSCHistoryProps): ReactElement => {
   if (status === EligibilityState.Kicked) {
     return (
       <>
-        <span className="text-xl text-white">{t`GSC History`}</span>
         <span className="mt-1 flex items-center">
           <span className="mr-1 w-max text-sm text-white underline">
             {t`Previously removed from GSC.`}
           </span>
           <Tooltip
             className="text-white"
-            content={t`Membership warning placeholder.`}
+            content={t`You are currently no longer a member of the GSC as you have been
+            removed. As you fell under 110,000 ELFI threshold the community
+            chose to remove you from the Council. To appeal this decision please
+            follow protocol you can read here to do so.`}
           >
             <InformationCircleIcon className="h-4 cursor-help" />
           </Tooltip>
-        </span>{" "}
+        </span>
       </>
     );
   }
 
   return (
-    <>
-      <span className="text-xl text-white">{t`GSC History`}</span>
-      <span className="w-max text-sm text-white">{t`Not eligible for the GSC.`}</span>
-    </>
+    <span className="w-max text-sm text-white">
+      {t`Not eligible for the GSC.`}
+    </span>
+  );
+}
+
+export const GSCHistory = ({ status }: GSCHistoryProps): ReactElement => {
+  return (
+    <div className="rounded-lg bg-black bg-opacity-20 p-3">
+      <div className="text-xl text-white">{t`GSC History`}</div>
+      <div className="whitespace-nowrap">{getGSCStatusText(status)}</div>
+    </div>
   );
 };

--- a/apps/elf-council-frontend/src/ui/gsc/GSCHistory.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCHistory.tsx
@@ -4,12 +4,19 @@ import { InformationCircleIcon } from "@heroicons/react/solid";
 import { t } from "ttag";
 import { EligibilityState } from "src/ui/gsc/useGSCStatus";
 import Tooltip from "src/ui/base/Tooltip/Tooltip";
+import { commify, formatEther } from "ethers/lib/utils";
 
 interface GSCHistoryProps {
   status: EligibilityState;
+  threshold: string;
 }
 
-function getGSCStatusText(status: EligibilityState): ReactElement {
+function getGSCStatusText({
+  status,
+  threshold,
+}: GSCHistoryProps): ReactElement {
+  const formattedThreshold = commify(Math.round(+formatEther(threshold)));
+
   if (status === EligibilityState.Eligible) {
     return (
       <>
@@ -79,7 +86,7 @@ function getGSCStatusText(status: EligibilityState): ReactElement {
           </span>
           <Tooltip
             className="text-white"
-            content={t`You’re currently under the 110,000 ELFI delegation threshold for the
+            content={t`You’re currently under the ${formattedThreshold} ELFI delegation threshold for the
             Governance Steering Council (GSC). Please be advised this means that
             community members are permitted to remove you from the Council.`}
           >
@@ -100,7 +107,7 @@ function getGSCStatusText(status: EligibilityState): ReactElement {
           <Tooltip
             className="text-white"
             content={t`You are currently no longer a member of the GSC as you have been
-            removed. As you fell under 110,000 ELFI threshold the community
+            removed. As you fell under ${formattedThreshold} ELFI threshold the community
             chose to remove you from the Council. To appeal this decision please
             follow protocol you can read here to do so.`}
           >
@@ -118,11 +125,16 @@ function getGSCStatusText(status: EligibilityState): ReactElement {
   );
 }
 
-export const GSCHistory = ({ status }: GSCHistoryProps): ReactElement => {
+export const GSCHistory = ({
+  status,
+  threshold,
+}: GSCHistoryProps): ReactElement => {
   return (
     <div className="rounded-lg bg-black bg-opacity-20 p-3">
       <div className="text-xl font-bold text-white">{t`GSC Status`}</div>
-      <div className="whitespace-nowrap">{getGSCStatusText(status)}</div>
+      <div className="whitespace-nowrap">
+        {getGSCStatusText({ status, threshold })}
+      </div>
     </div>
   );
 };

--- a/apps/elf-council-frontend/src/ui/gsc/GSCHistory.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCHistory.tsx
@@ -12,13 +12,41 @@ interface GSCHistoryProps {
 function getGSCStatusText(status: EligibilityState): ReactElement {
   if (status === EligibilityState.Eligible) {
     return (
-      <span className="w-max text-sm text-white">{t`Currently eligible to join the GSC!`}</span>
+      <>
+        <span className="mt-1 flex items-center">
+          <span className="text-md mr-1 w-max text-white">
+            {t`Eligible to join GSC`}
+          </span>
+          <Tooltip
+            className="text-white"
+            content={t`To learn more about our GSC program, its role within the Element DAO’s
+            Governance, and how it affects your experience as a member read more
+            here.`}
+          >
+            <InformationCircleIcon className="h-4 cursor-help" />
+          </Tooltip>
+        </span>
+      </>
     );
   }
 
   if (status === EligibilityState.Current) {
     return (
-      <span className="w-max text-sm text-white">{t`Currently in the GSC!`}</span>
+      <>
+        <span className="mt-1 flex items-center">
+          <span className="text-md mr-1 w-max text-white">
+            {t`Current member of the GSC`}
+          </span>
+          <Tooltip
+            className="text-white"
+            content={t`To learn more about our GSC program, its role within the Element DAO’s
+            Governance, and how it affects your experience as a member read more
+            here.`}
+          >
+            <InformationCircleIcon className="h-4 cursor-help" />
+          </Tooltip>
+        </span>
+      </>
     );
   }
 
@@ -26,8 +54,8 @@ function getGSCStatusText(status: EligibilityState): ReactElement {
     return (
       <>
         <span className="mt-1 flex items-center">
-          <span className="mr-1 w-max text-sm text-white underline">
-            {t`Membership Warning`}
+          <span className="text-md mr-1 w-max text-white">
+            {t`Approaching eligibility`}
           </span>
           <Tooltip
             className="text-white"
@@ -46,8 +74,8 @@ function getGSCStatusText(status: EligibilityState): ReactElement {
     return (
       <>
         <span className="mt-1 flex items-center">
-          <span className="mr-1 w-max text-sm text-white underline">
-            {t`Membership Warning`}
+          <span className="text-md mr-1 w-max text-white">
+            {t`Membership expiring`}
           </span>
           <Tooltip
             className="text-white"
@@ -66,8 +94,8 @@ function getGSCStatusText(status: EligibilityState): ReactElement {
     return (
       <>
         <span className="mt-1 flex items-center">
-          <span className="mr-1 w-max text-sm text-white underline">
-            {t`Previously removed from GSC.`}
+          <span className="text-md mr-1 w-max text-white">
+            {t`Previously removed from GSC`}
           </span>
           <Tooltip
             className="text-white"
@@ -84,8 +112,8 @@ function getGSCStatusText(status: EligibilityState): ReactElement {
   }
 
   return (
-    <span className="w-max text-sm text-white">
-      {t`Not eligible for the GSC.`}
+    <span className="text-md w-max text-white">
+      {t`Not eligible for joining the GSC`}
     </span>
   );
 }
@@ -93,7 +121,7 @@ function getGSCStatusText(status: EligibilityState): ReactElement {
 export const GSCHistory = ({ status }: GSCHistoryProps): ReactElement => {
   return (
     <div className="rounded-lg bg-black bg-opacity-20 p-3">
-      <div className="text-xl text-white">{t`GSC History`}</div>
+      <div className="text-xl font-bold text-white">{t`GSC Status`}</div>
       <div className="whitespace-nowrap">{getGSCStatusText(status)}</div>
     </div>
   );

--- a/apps/elf-council-frontend/src/ui/gsc/GSCPortfolioCard.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCPortfolioCard.tsx
@@ -13,7 +13,8 @@ import { JoinGSCButton, LeaveGSCButton } from "src/ui/gsc/GSCButtons";
 import { TooltipDefinition } from "src/ui/voting/tooltipDefinitions";
 import { ThresholdProgressBar } from "src/ui/gsc/ThresholdProgressBar";
 import { useGSCStatus, EligibilityState } from "src/ui/gsc/useGSCStatus";
-import { GSCHistory } from "./GSCHistory";
+import { GSCHistory } from "src/ui/gsc/GSCHistory";
+import { useGSCVotePowerThreshold } from "src/ui/gsc/useGSCVotePowerThreshold";
 
 interface PortfolioCardProps {
   account: string | undefined | null;
@@ -27,7 +28,7 @@ export function GSCPortfolioCard({
   signer,
 }: PortfolioCardProps): ReactElement {
   const formattedAddress = useFormattedWalletAddress(account, provider);
-
+  const { data: thresholdValue } = useGSCVotePowerThreshold();
   const { status, votingPower } = useGSCStatus(account);
   const canJoinGSC = status === EligibilityState.Eligible;
   const canLeaveGSC = status === EligibilityState.Expiring;
@@ -66,7 +67,10 @@ export function GSCPortfolioCard({
         <div className="mr-4 flex grow basis-72 flex-row items-center lg:ml-auto">
           {/* GSC History */}
           <div className="w-min-max mr-auto flex flex-col">
-            <GSCHistory status={status} />
+            <GSCHistory
+              status={status}
+              threshold={thresholdValue?.toString() ?? "0"}
+            />
           </div>
           <div className="ml-12">
             {canLeaveGSC ? (

--- a/apps/elf-council-frontend/src/ui/gsc/GSCPortfolioCard.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCPortfolioCard.tsx
@@ -31,6 +31,7 @@ export function GSCPortfolioCard({
   const { status, votingPower } = useGSCStatus(account);
   const canJoinGSC = status === EligibilityState.Eligible;
   const canLeaveGSC = status === EligibilityState.Expiring;
+  const isGSC = status === EligibilityState.Current;
 
   return (
     <Card variant={CardVariant.GRADIENT} className="w-fit shadow-md lg:w-full">
@@ -49,7 +50,7 @@ export function GSCPortfolioCard({
 
       <div className="mt-4 mb-4 flex min-h-full min-w-fit flex-row flex-wrap items-center space-y-6 xl:space-y-0">
         {/* GSC eligibility progress bar */}
-        <div className="flex grow-[2] basis-[30rem] flex-wrap space-y-6 lg:space-y-0">
+        <div className="flex grow-[2] basis-[34rem] flex-wrap space-y-6 lg:space-y-0">
           {/* Voting Power */}
           <BalanceWithLabel
             className="mr-4 basis-52"
@@ -58,24 +59,27 @@ export function GSCPortfolioCard({
             label={t`Voting Power`}
           />
           <div className="mr-8 flex max-w-md grow items-center align-middle">
-            <ThresholdProgressBar account={account} />
+            <ThresholdProgressBar account={account} gscStatus={status} />
           </div>
         </div>
 
-        <div className="mr-2 flex grow basis-72 flex-row items-center lg:ml-auto">
+        <div className="mr-4 flex grow basis-72 flex-row items-center lg:ml-auto">
           {/* GSC History */}
-          <div className="mr-auto flex w-fit flex-col">
+          <div className="w-min-max mr-auto flex flex-col">
             <GSCHistory status={status} />
           </div>
-          {canLeaveGSC ? (
-            <LeaveGSCButton account={account} signer={signer} />
-          ) : (
-            <JoinGSCButton
-              account={account}
-              signer={signer}
-              disabled={!canJoinGSC || !account}
-            />
-          )}
+          <div className="ml-12">
+            {canLeaveGSC ? (
+              <LeaveGSCButton account={account} signer={signer} />
+            ) : (
+              <JoinGSCButton
+                account={account}
+                signer={signer}
+                disabled={!canJoinGSC || !account}
+                isGSC={isGSC}
+              />
+            )}
+          </div>
         </div>
       </div>
     </Card>

--- a/apps/elf-council-frontend/src/ui/gsc/GSCPortfolioCard.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCPortfolioCard.tsx
@@ -47,18 +47,17 @@ export function GSCPortfolioCard({
         )}
       </div>
 
-      <div className="mt-4 mb-4 flex min-h-full min-w-fit flex-row flex-wrap items-center space-y-6 lg:space-y-0">
-        {/* Voting Power */}
-        <BalanceWithLabel
-          className="mr-4 basis-52"
-          balance={votingPower}
-          tooltipText={t`${TooltipDefinition.OWNED_VOTING_POWER}`}
-          label={t`Voting Power`}
-        />
-
+      <div className="mt-4 mb-4 flex min-h-full min-w-fit flex-row flex-wrap items-center space-y-6 xl:space-y-0">
         {/* GSC eligibility progress bar */}
-        <div className="flex-shrink-0 grow-[2] basis-72">
-          <div className="mr-8 flex max-w-md items-center align-middle">
+        <div className="flex grow-[2] basis-[30rem] flex-wrap space-y-6 lg:space-y-0">
+          {/* Voting Power */}
+          <BalanceWithLabel
+            className="mr-4 basis-52"
+            balance={votingPower}
+            tooltipText={t`${TooltipDefinition.OWNED_VOTING_POWER}`}
+            label={t`Voting Power`}
+          />
+          <div className="mr-8 flex max-w-md grow items-center align-middle">
             <ThresholdProgressBar account={account} />
           </div>
         </div>

--- a/apps/elf-council-frontend/src/ui/gsc/ThresholdProgressBar.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/ThresholdProgressBar.tsx
@@ -42,7 +42,11 @@ export function ThresholdProgressBar({
         <span className="text-lg">{t`GSC Eligibility`}</span>
       </div>
       <ProgressBar
-        progress={+votingPower / +threshold}
+        progress={
+          gscStatus === EligibilityState.Expiring
+            ? 100
+            : +votingPower / +threshold
+        }
         color={getProgressBarColor(gscStatus)}
       />
       <div>

--- a/apps/elf-council-frontend/src/ui/gsc/ThresholdProgressBar.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/ThresholdProgressBar.tsx
@@ -8,13 +8,27 @@ import { useVotingPowerForAccountAtLatestBlock } from "src/ui/voting/useVotingPo
 import { ProgressBar } from "src/ui/base/ProgressBar/ProgressBar";
 
 import { formatBalance2 } from "@elementfi/base/utils/formatBalance/formatBalance";
+import { EligibilityState } from "src/ui/gsc/useGSCStatus";
 
 interface ThresholdProgressBarProps {
   account: string | null | undefined;
+  gscStatus?: EligibilityState;
 }
+
+// Returns tailwind color for progress bar background
+const getProgressBarColor = (status?: EligibilityState) => {
+  if (status === EligibilityState.Current) {
+    return "bg-votingGreen";
+  }
+
+  if (status === EligibilityState.Expiring) {
+    return "bg-deepRed";
+  }
+};
 
 export function ThresholdProgressBar({
   account,
+  gscStatus,
 }: ThresholdProgressBarProps): ReactElement {
   const { data: thresholdValue } = useGSCVotePowerThreshold();
   const threshold = formatEther(thresholdValue || 0);
@@ -23,13 +37,16 @@ export function ThresholdProgressBar({
   const votingPercent = Math.floor((+votingPower / +threshold) * 100);
 
   return (
-    <div className="mr-3 w-full space-y-1 text-white">
+    <div className="w-full mr-3 space-y-1 text-white">
       <div>
         <span className="text-lg">{t`GSC Eligibility`}</span>
       </div>
-      <ProgressBar progress={+votingPower / +threshold} />
-      <div className="text-sm leading-5">
-        <span>
+      <ProgressBar
+        progress={+votingPower / +threshold}
+        color={getProgressBarColor(gscStatus)}
+      />
+      <div>
+        <span className="text-sm leading-5">
           {`${votingPercent}%`} ({formatBalance2(votingPower, 4)} /{" "}
           {commify(threshold)} ){" "}
         </span>

--- a/apps/elf-council-frontend/src/ui/gsc/ThresholdProgressBar.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/ThresholdProgressBar.tsx
@@ -37,7 +37,7 @@ export function ThresholdProgressBar({
   const votingPercent = Math.floor((+votingPower / +threshold) * 100);
 
   return (
-    <div className="w-full mr-3 space-y-1 text-white">
+    <div className="mr-3 w-full space-y-1 text-white">
       <div>
         <span className="text-lg">{t`GSC Eligibility`}</span>
       </div>

--- a/apps/elf-council-frontend/src/ui/gsc/useGSCVotePowerThreshold.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/useGSCVotePowerThreshold.tsx
@@ -6,5 +6,7 @@ import { BigNumber } from "ethers";
 import { gscVaultContract } from "src/elf/contracts";
 
 export function useGSCVotePowerThreshold(): QueryObserverResult<BigNumber> {
-  return useSmartContractReadCall(gscVaultContract, "votingPowerBound");
+  return useSmartContractReadCall(gscVaultContract, "votingPowerBound", {
+    keepPreviousData: true,
+  });
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15604932/168202758-e2232a2e-d22a-405d-ba55-9c8b2799b908.png)


- New colors for danger button variant
- Customizable color and bigger threshold progress bar
- Delegate button custom disable prop
- GSC Join button shows Joined if joined
- GSC History refactor. Bigger, bolder text and copy is more consistent.
- abstracted getTopTwentyCandidates logic to a function
- GSC Portfolio card css changes
- Delegation/kick button disabled if account is GSC