### PR TITLE
GSC fix empty ENS name and kick button wrongly being rendered

### DIFF
--- a/apps/elf-council-frontend/src/ui/ethereum/useEnsName.tsx
+++ b/apps/elf-council-frontend/src/ui/ethereum/useEnsName.tsx
@@ -1,9 +1,10 @@
 import { Provider } from "@ethersproject/providers";
 import { QueryObserverResult, useQuery } from "react-query";
+import { defaultProvider } from "src/elf/providers/providers";
 
 export function useENSName(
   account: string | null | undefined,
-  provider?: Provider,
+  provider: Provider = defaultProvider,
 ): QueryObserverResult<string> {
   return useQuery({
     queryKey: ["provider", "lookupAddress", account],

--- a/apps/elf-council-frontend/src/ui/gsc/GSCMemberProfileRow.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCMemberProfileRow.tsx
@@ -13,6 +13,9 @@ import {
 import { useVotingPowerForAccountAtLatestBlock } from "src/ui/voting/useVotingPowerForAccount";
 import { WalletJazzicon } from "src/ui/wallet/WalletJazzicon";
 import { useENSName } from "src/ui/ethereum/useEnsName";
+import { useGSCVotePowerThreshold } from "./useGSCVotePowerThreshold";
+import { formatEther } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
 
 interface GSCMemberProfileRowProps {
   selected: boolean;
@@ -32,6 +35,11 @@ export function GSCMemberProfileRow(
     delegateButton,
     kickButton,
   } = props;
+
+  const votePower = useVotingPowerForAccountAtLatestBlock(delegate.address);
+  const { data: thresholdValue } = useGSCVotePowerThreshold();
+  const formattedThreshold = thresholdValue && formatEther(thresholdValue);
+  const isKickable = formattedThreshold && +formattedThreshold > +votePower;
 
   const { data: ensName } = useENSName(delegate.address);
   const formattedDelegateName =
@@ -94,7 +102,9 @@ export function GSCMemberProfileRow(
       {/* Buttons */}
       <div className="col-span-4 flex justify-end gap-x-4">
         {/* Unique action event button */}
-        <div className="w-1/2 lg:pl-2">{kickButton}</div>
+        <div className="w-1/2 lg:pl-2">
+          {isKickable ? kickButton : undefined}
+        </div>
         <div className="w-1/2 lg:pl-2">{delegateButton}</div>
       </div>
     </div>

--- a/apps/elf-council-frontend/src/ui/gsc/GSCMemberProfileRow.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCMemberProfileRow.tsx
@@ -16,6 +16,7 @@ import { useENSName } from "src/ui/ethereum/useEnsName";
 import { useGSCVotePowerThreshold } from "./useGSCVotePowerThreshold";
 import { formatEther } from "ethers/lib/utils";
 import { BigNumber } from "ethers";
+import { defaultProvider } from "src/elf/providers/providers";
 
 interface GSCMemberProfileRowProps {
   selected: boolean;
@@ -35,7 +36,6 @@ export function GSCMemberProfileRow(
     delegateButton,
     kickButton,
   } = props;
-
   const votePower = useVotingPowerForAccountAtLatestBlock(delegate.address);
   const { data: thresholdValue } = useGSCVotePowerThreshold();
   const formattedThreshold = thresholdValue && formatEther(thresholdValue);

--- a/apps/elf-council-frontend/src/ui/gsc/GSCOverviewSection.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCOverviewSection.tsx
@@ -295,27 +295,7 @@ function sortMembersByVotingPower(
   });
 }
 
-function getKickableMembers(
-  members: Delegate[],
-  votePowerByDelegate: VotePowerByDelegate,
-  threshold: BigNumber,
-): Set<string> {
-  const validMembers: Set<string> = new Set();
-
-  members.forEach((member) => {
-    const address = member.address;
-    const votingPower = votePowerByDelegate[address];
-
-    if (votingPower && votingPower.lt(threshold)) {
-      validMembers.add(address);
-    }
-  });
-
-  return validMembers;
-}
-
 const NUM_CANDIDATES_TO_SHOW = 20;
-
 function getTopTwentyCandidates(
   candidates: Delegate[] = [],
   votingPowerByDelegate: VotePowerByDelegate = {},

--- a/apps/elf-council-frontend/src/ui/gsc/GSCOverviewSection.tsx
+++ b/apps/elf-council-frontend/src/ui/gsc/GSCOverviewSection.tsx
@@ -57,16 +57,9 @@ export function GSCOverviewSection(): ReactElement {
     votingPowerByDelegate,
   );
 
-  // Find GSC members that are kickable
-  const { data: thresholdValue } = useGSCVotePowerThreshold();
-  const kickableMembers = getKickableMembers(
-    [...members],
-    votingPowerByDelegate,
-    thresholdValue ?? BigNumber.from(0),
-  );
-
   // Fetch current GSC candidates
   const candidates = useGSCCandidates();
+  const { data: thresholdValue } = useGSCVotePowerThreshold();
   const topTwentyCandidates = getTopTwentyCandidates(
     candidates,
     votingPowerByDelegate,
@@ -212,23 +205,21 @@ export function GSCOverviewSection(): ReactElement {
                     const currentlyDelegated =
                       currentDelegate === member.address;
 
-                    const kickButton = kickableMembers.has(member.address) ? (
-                      <Button
-                        variant={ButtonVariant.DANGER}
-                        className="w-full text-center"
-                        onClick={() => handleKick(member.address)}
-                        loading={isLeaveTxnLoading}
-                      >
-                        <div className="flex w-full justify-center">{t`Kick`}</div>
-                      </Button>
-                    ) : undefined;
-
                     return (
                       <li key={member.address}>
                         <GSCMemberProfileRow
                           selected={false}
                           delegate={member}
-                          kickButton={kickButton}
+                          kickButton={
+                            <Button
+                              variant={ButtonVariant.DANGER}
+                              className="w-full text-center"
+                              onClick={() => handleKick(member.address)}
+                              loading={isLeaveTxnLoading}
+                            >
+                              <div className="flex w-full justify-center">{t`Kick`}</div>
+                            </Button>
+                          }
                           delegateButton={
                             <ChangeDelegateButton
                               onDelegationClick={() =>


### PR DESCRIPTION
Fixed ens name hook by setting the default provider as the default value for the parameter.

The kick button was wrongly being rendered if the delegate has a lot of delegations from the vesting vault, due to calculations. I refactored where and how we calculate voting power.