### PR TITLE
Update delegates list

### DIFF
--- a/apps/elf-council-frontend/package.json
+++ b/apps/elf-council-frontend/package.json
@@ -103,6 +103,7 @@
     "dev-mainnet": "cross-env NEXT_PUBLIC_CHAIN_NAME=mainnet next dev",
     "dev-mainnet-fork": "cross-env NEXT_PUBLIC_CHAIN_NAME=mainnet-fork next dev",
     "start": "next start",
+    "scrape-delegates": "bash scripts/scrape-delegates.sh",
     "_copy-testnet-addresses": "cp ../elf-council-testnet/src/addresses/testnet.addresses.json src/elf-council-addresses/testnet.addresses.json",
     "_copy-testnet-tokenlist": "cp ../elf-council-testnet/src/tokenlist/testnet.tokenlist.json src/elf-council-tokenlist/testnet.tokenlist.json",
     "copy-testnet": "npm run _copy-testnet-addresses && npm run _copy-testnet-tokenlist",

--- a/apps/elf-council-frontend/scripts/scrape-delegates.sh
+++ b/apps/elf-council-frontend/scripts/scrape-delegates.sh
@@ -1,0 +1,15 @@
+# Mainnet only
+curl -s "https://forum.element.fi/api/viewComments?chain=element-finance&root_id=discussion_4146" |
+  jq '{ 
+  result: [.result[] 
+    | select(.deleted_at = null)
+    | select(.plaintext | ascii_downcase | contains("statement of intent") or length > 280)
+    | select(.plaintext | ascii_downcase | contains("ethereum address"))
+    | { 
+	commonwealthCommentId: .id,
+	"commonweathName": .Address["name"],
+	"commonwealthPostedFromAddress": .Address["address"],
+	"address": .plaintext | match("0x[a-fA-F0-9]{40}").string,
+	created_at,
+      }]}' > src/elf-council-delegates/delegate_mainnet_scraped_results.json
+

--- a/apps/elf-council-frontend/src/elf-council-delegates/delegate_mainnet_scraped_results.json
+++ b/apps/elf-council-frontend/src/elf-council-delegates/delegate_mainnet_scraped_results.json
@@ -1,6 +1,5 @@
 {
-  "chainId": 1,
-  "delegates": [
+  "result": [
     {
       "commonwealthCommentId": 20414,
       "commonweathName": "Blockchain@Columbia",
@@ -126,6 +125,13 @@
       "commonwealthPostedFromAddress": "0xc5deFE70073E5D3B609F2907683d9BEE0E9c6768",
       "address": "0x1D1a13b16667c284b87de62CAEEfF0ce89E342B2",
       "created_at": "2022-03-30T15:34:50.453Z"
+    },
+    {
+      "commonwealthCommentId": 18067,
+      "commonweathName": "Bobby | StableNode",
+      "commonwealthPostedFromAddress": "0xc5deFE70073E5D3B609F2907683d9BEE0E9c6768",
+      "address": "0x1D1a13b16667c284b87de62CAEEfF0ce89E342B2",
+      "created_at": "2022-03-30T15:29:43.603Z"
     },
     {
       "commonwealthCommentId": 18063,
@@ -462,6 +468,13 @@
       "commonwealthPostedFromAddress": "0x2c66D11c2652b96301ee9caA61663b757d0BA2cd",
       "address": "0x2c66D11c2652b96301ee9caA61663b757d0BA2cd",
       "created_at": "2022-03-29T04:22:05.150Z"
+    },
+    {
+      "commonwealthCommentId": 17939,
+      "commonweathName": "BlackHare",
+      "commonwealthPostedFromAddress": "0x885ea391039e0FA3f6833a1F3B6d7433B5b69bb6",
+      "address": "0x885ea391039e0FA3f6833a1F3B6d7433B5b69bb6",
+      "created_at": "2022-03-29T04:21:59.189Z"
     },
     {
       "commonwealthCommentId": 17938,
@@ -842,6 +855,13 @@
       "created_at": "2022-03-25T19:48:06.796Z"
     },
     {
+      "commonwealthCommentId": 17775,
+      "commonweathName": "Bankloos",
+      "commonwealthPostedFromAddress": "0xF7791248951DA4F9221fe4EfA0a3a9825B48861D",
+      "address": "0xF7791248951DA4F9221fe4EfA0a3a9825B48861D",
+      "created_at": "2022-03-25T19:46:00.783Z"
+    },
+    {
       "commonwealthCommentId": 17757,
       "commonweathName": "vva",
       "commonwealthPostedFromAddress": "0x7c199031de580ECb75D5aE0bdeBBFE2e23b4BBAE",
@@ -953,6 +973,5 @@
       "address": "0x9FfD0a5b5438B95861167422E745D34d151bcc3b",
       "created_at": "2022-03-23T21:11:55.172Z"
     }
-  ],
-  "version": "0.0.0"
+  ]
 }

--- a/apps/elf-council-frontend/src/elf-council-delegates/delegates.ts
+++ b/apps/elf-council-frontend/src/elf-council-delegates/delegates.ts
@@ -17,7 +17,6 @@ export interface Delegate {
   commonwealthCommentId?: number;
   commonwealthName?: string | null;
   name?: string;
-  ensName?: string | null;
   description?: string;
 
   /**


### PR DESCRIPTION
- Adds a handful of new delegate applications to the delegates.json.
- brings over the initial scraping script from the council ui launch: https://gist.github.com/DannyDelott/c8bd46d9581c492c437175163377a8eb
- Removed the `plaintext` and `ensName` fields from the Delegate interface, as they were unused

We'll soon figure out a more pragmatic way to update the delegate applications on a schedule, and with less manual cleaning, see: https://app.clickup.com/t/2cc1tux