### PR TITLE
Add more delegates

### DIFF
--- a/apps/elf-council-frontend/src/elf-council-delegates/delegates.ts
+++ b/apps/elf-council-frontend/src/elf-council-delegates/delegates.ts
@@ -3,6 +3,8 @@ import { ChainId } from "src/ethereum";
 
 import testnetDelegatesJson from "src/elf-council-delegates/testnet.delegates.json";
 import mainnetDelegatesJson from "src/elf-council-delegates/mainnet.delegates.json";
+// extra delegates that weren't scrape-able by our current script, these had to be hardcoded :(
+import mainnetExtrasDelegatesJson from "src/elf-council-delegates/mainnet-extras.delegates.json";
 import goerliDelegatesJson from "src/elf-council-delegates/goerli.delegates.json";
 
 export interface DelegatesJson {
@@ -33,7 +35,10 @@ function getDelegates(): Delegate[] {
   }
 
   if (addressesJson.chainId === ChainId.MAINNET) {
-    return mainnetDelegatesJson.delegates;
+    return [
+      ...mainnetDelegatesJson.delegates,
+      ...mainnetExtrasDelegatesJson.delegates,
+    ];
   }
 
   if (addressesJson.chainId === ChainId.LOCAL) {

--- a/apps/elf-council-frontend/src/elf-council-delegates/mainnet-extras.delegates.json
+++ b/apps/elf-council-frontend/src/elf-council-delegates/mainnet-extras.delegates.json
@@ -1,0 +1,20 @@
+{
+  "chainId": 1,
+  "delegates": [
+    {
+      "commonwealthCommentId": 17924,
+      "commonwealthName": "moshimo",
+      "commonwealthPostedFromAddress": "0x32C2741DC6621CcD32D868727bE74dCdC7aB332F",
+      "address": "0x32C2741DC6621CcD32D868727bE74dCdC7aB332F",
+      "created_at": "2022-03-29T02:16:21.531Z"
+    },
+    {
+      "commonwealthCommentId": 17924,
+      "commonwealthName": "simona pop",
+      "commonwealthPostedFromAddress": "0x54BeCc7560a7Be76d72ED76a1f5fee6C5a2A7Ab6",
+      "address": "0x54BeCc7560a7Be76d72ED76a1f5fee6C5a2A7Ab6",
+      "created_at": "2022-04-30T09:24:29.359Z"
+    }
+  ],
+  "version": "0.0.0"
+}


### PR DESCRIPTION
Band-aid solution for non-conforming delegate applications is to just hardcode them for now and merge them in with the scraped delegates.