### PR TITLE
remove merkle info requirement for voting

### DIFF
--- a/apps/council-frontend/src/ui/voting/useVote.ts
+++ b/apps/council-frontend/src/ui/voting/useVote.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 
+import { CoreVoting } from "@elementfi/council-typechain";
 import {
   useSmartContractTransaction,
   UseSmartContractTransactionOptions,
@@ -10,12 +11,10 @@ import { ethers, Signer } from "ethers";
 import { addressesJson } from "src/elf-council-addresses";
 import { coreVotingContract } from "src/elf/contracts";
 import { MerkleProof } from "src/elf/merkle/MerkleProof";
-import { MerkleRewardType, useMerkleInfo } from "src/elf/merkle/useMerkleInfo";
 import { useLatestBlockNumber } from "src/ui/ethereum/useLatestBlockNumber";
 import { Ballot } from "src/ui/voting/Ballot";
 import { useLockingVaultVotingPower } from "src/ui/voting/useLockingVaultVotingPower";
 import { useVestingVaultVotingPower } from "src/ui/voting/useVestingVaultVotingPower";
-import { CoreVoting } from "@elementfi/council-typechain";
 
 const { lockingVault: lockingVaultAddress, vestingVault: vestingVaultAddress } =
   addressesJson.addresses;
@@ -32,7 +31,6 @@ export function useVote(
   isError: boolean;
 } {
   const { data: latestBlockNumber } = useLatestBlockNumber();
-  const { data: merkleInfo } = useMerkleInfo(account, MerkleRewardType.RETRO);
 
   const {
     mutate: vote,
@@ -55,7 +53,7 @@ export function useVote(
     (proposalId: string, ballot: Ballot) => {
       const blockNumber = proposalCreatedAtBlockNumber || latestBlockNumber;
 
-      if (!blockNumber || !merkleInfo || !account) {
+      if (!blockNumber || !account) {
         return;
       }
 
@@ -83,7 +81,6 @@ export function useVote(
       proposalCreatedAtBlockNumber,
       latestBlockNumber,
       lockingVaultVotingPower,
-      merkleInfo,
       vestingVaultVotingPower,
       vote,
     ],


### PR DESCRIPTION
I can't for the life of me think why we'd need this.  i don't see any harm in removing it, doesn't affect any logic for voting.  there is a user that has a problem where they can't vote and I can see in the console that the merkle json is getting 403'd so I'm removing this.