### PR TITLE
Touch up proposal details cards markdown

### DIFF
--- a/apps/council-frontend/src/ui/proposals/ProposalsDetailsCard/ProposalDetailsCard.tsx
+++ b/apps/council-frontend/src/ui/proposals/ProposalsDetailsCard/ProposalDetailsCard.tsx
@@ -67,6 +67,7 @@ const markdownComponents: ReactMarkdownOptions["components"] = {
       {props.children}
     </a>
   ),
+  pre: (props) => <pre className="whitespace-pre-line">{props.children}</pre>,
 };
 
 export function ProposalDetailsCard(


### PR DESCRIPTION
`pre` tags converted through `react-markdown` are not currently wrapped to fit the width of the description

| Current | Proposed |
|---------|-----------|
|<img width="300" alt="Screen Shot 2022-05-31 at 12 50 41 PM" src="https://user-images.githubusercontent.com/19617238/172729815-56be2390-f879-4b96-b124-056b2c8d5e52.png"> | <img width="300" alt="Screen Shot 2022-05-31 at 12 50 41 PM" src="https://user-images.githubusercontent.com/19617238/172729808-4894df2d-ef2a-4d55-8257-abf672e2e3f0.png"> |