### PR TITLE
[core-v2-sdk] Add example test

### DIFF
--- a/packages/core-v2-sdk/contracts/LiquidityPool.sol
+++ b/packages/core-v2-sdk/contracts/LiquidityPool.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -15,7 +16,7 @@ contract LiquidityPool {
   event BuyTokens(address user, uint256 value, uint256 tokenAmount);
   event SellTokens(address user, uint256 value, uint256 tokenAmount);
 
-  constructor(ERC20 _poolToken, ERC20 _token) public {
+  constructor(ERC20 _poolToken, ERC20 _token) {
     poolToken = _poolToken;
     token = _token;
   }
@@ -75,7 +76,7 @@ contract LiquidityPool {
     tokenBalance += tokenAmount;
     cryptoBalance -= amount;
 
-    msg.sender.transfer(amount);
+    payable(msg.sender).transfer(amount);
 
     emit SellTokens(msg.sender, amount, tokenAmount);
   }

--- a/packages/core-v2-sdk/contracts/LiquidityPool.sol
+++ b/packages/core-v2-sdk/contracts/LiquidityPool.sol
@@ -1,0 +1,82 @@
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract LiquidityPool {
+  ERC20 public poolToken;
+  ERC20 public token;
+
+  uint256 public tokenBalance;
+  uint256 public cryptoBalance;
+
+  uint256 public constant MANTISSA = 1e18;
+
+  event Deposit(address user, uint256 value, uint256 tokenAmount);
+  event BuyTokens(address user, uint256 value, uint256 tokenAmount);
+  event SellTokens(address user, uint256 value, uint256 tokenAmount);
+
+  constructor(ERC20 _poolToken, ERC20 _token) public {
+    poolToken = _poolToken;
+    token = _token;
+  }
+
+  function deposit(uint256 tokenAmount) public payable {
+    require(token.transferFrom(msg.sender, address(this), tokenAmount));
+
+    if (tokenBalance == 0 && cryptoBalance == 0) {
+      tokenBalance = tokenAmount;
+      cryptoBalance = msg.value;
+
+      emit Deposit(msg.sender, msg.value, tokenAmount);
+
+      return;
+    }
+
+    uint256 tokenDepositAmount = (((tokenBalance * MANTISSA) / cryptoBalance) *
+      msg.value) / MANTISSA;
+
+    require(tokenDepositAmount <= tokenAmount);
+
+    tokenBalance += tokenDepositAmount;
+    cryptoBalance += msg.value;
+
+    emit Deposit(msg.sender, msg.value, tokenDepositAmount);
+
+    if (tokenDepositAmount < tokenAmount)
+      token.transfer(msg.sender, tokenAmount - tokenDepositAmount);
+  }
+
+  function getTokenPrice() public view returns (uint256) {
+    return (cryptoBalance * MANTISSA) / tokenBalance;
+  }
+
+  function buyTokens() public payable {
+    uint256 amount = msg.value;
+
+    uint256 tokenAmount = tokenBalance -
+      (tokenBalance * cryptoBalance) /
+      (cryptoBalance + amount);
+
+    tokenBalance -= tokenAmount;
+    cryptoBalance += amount;
+
+    require(token.transfer(msg.sender, tokenAmount));
+
+    emit BuyTokens(msg.sender, msg.value, tokenAmount);
+  }
+
+  function sellTokens(uint256 tokenAmount) public {
+    require(token.transferFrom(msg.sender, address(this), tokenAmount));
+
+    uint256 amount = cryptoBalance -
+      (tokenBalance * cryptoBalance) /
+      (tokenBalance + tokenAmount);
+
+    tokenBalance += tokenAmount;
+    cryptoBalance -= amount;
+
+    msg.sender.transfer(amount);
+
+    emit SellTokens(msg.sender, amount, tokenAmount);
+  }
+}

--- a/packages/core-v2-sdk/contracts/MockERC20.sol
+++ b/packages/core-v2-sdk/contracts/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+  constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+  function mint(address who, uint256 amount) public {
+    _mint(who, amount);
+  }
+}

--- a/packages/core-v2-sdk/hardhat.config.ts
+++ b/packages/core-v2-sdk/hardhat.config.ts
@@ -1,3 +1,4 @@
+import "@typechain/hardhat";
 import "@nomiclabs/hardhat-ethers";
 import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
@@ -11,7 +12,9 @@ dotenv.config();
 // Go to https://hardhat.org/config/ to learn more
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.4",
+  solidity: {
+    compilers: [{ version: "0.8.4" }, { version: "0.6.0" }],
+  },
   mocha: { timeout: 0 },
   paths: {
     tests: "./src",

--- a/packages/core-v2-sdk/package.json
+++ b/packages/core-v2-sdk/package.json
@@ -4,7 +4,8 @@
   "description": "Element SDK for V2 contracts",
   "main": "index.js",
   "scripts": {
-    "test": "TS_NODE_TRANSPILE_ONLY=1 npx hardhat test"
+    "test": "TS_NODE_TRANSPILE_ONLY=1 npx hardhat test",
+    "build": "TS_NODE_TRANSPILE_ONLY=1 npx hardhat compile"
   },
   "repository": {
     "type": "git",

--- a/packages/core-v2-sdk/package.json
+++ b/packages/core-v2-sdk/package.json
@@ -18,7 +18,8 @@
   "homepage": "https://github.com/element-fi/frontend-monorepo/apps/#readme",
   "dependencies": {
     "@elementfi/core-typechain": "*",
-    "@elementfi/council-typechain": "*"
+    "@elementfi/council-typechain": "*",
+    "@openzeppelin/contracts": "^4.6.0"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.6",

--- a/packages/core-v2-sdk/src/tradePrincipalTokens/tradePrincipalTokens.test.ts
+++ b/packages/core-v2-sdk/src/tradePrincipalTokens/tradePrincipalTokens.test.ts
@@ -1,31 +1,69 @@
+import { tradePrincipalTokens } from "src/tradePrincipalTokens/tradePrincipalTokens";
+/* eslint-disable no-restricted-imports */
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
+import { parseEther } from "ethers/lib/utils";
 import hre, { ethers } from "hardhat";
 
-import { tradePrincipalTokens } from "src/tradePrincipalTokens/tradePrincipalTokens";
-
-const tokenInAddress = ethers.constants.AddressZero;
-const tokenOutAddress = ethers.constants.AddressZero;
-const vaultAddress = ethers.constants.AddressZero;
+// TODO add tsconfig-paths/register to hardhat config
+import { LiquidityPool__factory } from "../../typechain/factories/LiquidityPool__factory";
+import { MockERC20__factory } from "../../typechain/factories/MockERC20__factory";
+import { LiquidityPool } from "../../typechain/LiquidityPool";
+import { MockERC20 } from "../../typechain/MockERC20";
 
 describe("tradePrincipalTokens", () => {
   let signers: SignerWithAddress[];
   let signer: SignerWithAddress;
+  let tokenContract: MockERC20;
+  let poolTokenContract: MockERC20;
+  let liquidityPoolContract: LiquidityPool;
 
   beforeEach(async () => {
     signers = await hre.ethers.getSigners();
     [signer] = signers;
+    tokenContract = await deployToken("token", "T", signer);
+    poolTokenContract = await deployToken("poolToken", "PT", signer);
+    liquidityPoolContract = await deployLiquidityPool(
+      signer,
+      tokenContract.address,
+      poolTokenContract.address,
+    );
   });
 
-  it("Should return a transaction", async () => {
-    const tx = await tradePrincipalTokens(
-      tokenInAddress,
-      tokenOutAddress,
-      vaultAddress,
-      "1",
-      ".01",
-      signer,
-    );
-    expect(tx.from).to.equal(signer.address);
+  it("Should deposit", async () => {
+    const depositAmount = parseEther("1");
+    await tokenContract.connect(signer).mint(signer.address, parseEther("100"));
+    await tokenContract
+      .connect(signer)
+      .approve(liquidityPoolContract.address, ethers.constants.MaxUint256);
+
+    await expect(liquidityPoolContract.deposit(depositAmount))
+      .to.emit(liquidityPoolContract, "Deposit")
+      .withArgs(signer.address, 0, depositAmount);
+
+    // expect(tokenBalance).to.equal(depositAmount);
   });
 });
+
+async function deployLiquidityPool(
+  signer: SignerWithAddress,
+  tokenAddress: string,
+  poolTokenAddress: string,
+): Promise<LiquidityPool> {
+  const deployer = new LiquidityPool__factory(signer);
+
+  const contract = await deployer.deploy(poolTokenAddress, tokenAddress);
+
+  return contract;
+}
+
+async function deployToken(
+  name: string,
+  symbol: string,
+  signer: SignerWithAddress,
+): Promise<MockERC20> {
+  const tokenDeployer = new MockERC20__factory(signer);
+  const tokenContract = await tokenDeployer.deploy(name, symbol);
+
+  return tokenContract;
+}

--- a/packages/core-v2-sdk/tsconfig.json
+++ b/packages/core-v2-sdk/tsconfig.json
@@ -11,8 +11,9 @@
     "declaration": true
   },
   "paths": {
-    "src/*": ["./src/*"]
+    "src/*": ["./src/*"],
+    "typechain/*": ["./typechain/*"]
   },
-  "include": ["./src"],
+  "include": ["./src", "./typechain"],
   "files": ["./hardhat.config.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3702,7 +3702,7 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"
   integrity sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==
 
-"@openzeppelin/contracts@^4.2.0", "@openzeppelin/contracts@^4.4.2":
+"@openzeppelin/contracts@^4.2.0", "@openzeppelin/contracts@^4.4.2", "@openzeppelin/contracts@^4.6.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
   integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
@@ -6098,10 +6098,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.38", "@types/react@17.0.44", "@types/react@^17", "@types/react@^17.0.38", "@types/react@^17.0.39":
+"@types/react@*", "@types/react@17.0.44", "@types/react@^17", "@types/react@^17.0.38", "@types/react@^17.0.39":
   version "17.0.44"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
   integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@17.0.38":
+  version "17.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
+  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -23948,7 +23957,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snarkjs@0.4.10, snarkjs@^0.4.10:
+snarkjs@^0.4.10:
   version "0.4.10"
   resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.4.10.tgz#5a8048e691af8f3e6016014ba2cb0e916f508be1"
   integrity sha512-YWgxso7CGcSfkyDGraVjPuBJtq6GEsZ16YBJj2eD0TFum2D5BxnawvyTo4p/7UpctAT0r05DoHo80zgaWnbIKA==


### PR DESCRIPTION
A basic example test showcasing how to use sample contracts.  By using dummy or simple versions of contracts before we have the core v2 contracts, we can stub out sdk methods.  this is an example of how to do that using a simple LiquidityPool and MockERC20 contract.