### PR TITLE
Add eslint to council-frontend app

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,7 @@
 
 .next
 
-# elf-frontend 
+# core-frontend 
 apps/core-frontend/src/version.output.json
 
 # council-testnet

--- a/apps/council-frontend/.eslintrc
+++ b/apps/council-frontend/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "@elementfi/eslint-config"
+  ]
+}

--- a/apps/council-frontend/.eslintrc
+++ b/apps/council-frontend/.eslintrc
@@ -1,5 +1,17 @@
 {
   "extends": [
     "@elementfi/eslint-config"
+  ],
+  "overrides": [
+    // js files in the root dir can use `const ... = require(...)` 
+    { 
+      "files": [
+        "./*.js",
+        "tests/**/.eslintrc.js"
+      ],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    }
   ]
 }

--- a/apps/council-frontend/package.json
+++ b/apps/council-frontend/package.json
@@ -7,6 +7,7 @@
     "@elementfi/council-proposals": "*",
     "@elementfi/council-tokenlist": "*",
     "@elementfi/council-typechain": "*",
+    "@elementfi/eslint-config": "*",
     "@elementfi/react-query-typechain": "*",
     "@ethersproject/providers": "^5.6.5",
     "@fontsource/roboto-mono": "^4.5.3",
@@ -43,10 +44,13 @@
     "d3-format": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "date-fns": "^2.28.0",
+    "eslint": "^7.32.0",
     "env-cmd": "^10.1.0",
     "ethers": "^5.6.6",
     "graphql": "^15.8.0",
     "graphql-request": "^3.7.0",
+    "husky": "^7.0.4",
+    "lint-staged": "^12.3.7",
     "lodash.isequal": "^4.5.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isnumber": "^3.0.3",
@@ -113,7 +117,15 @@
     "chromatic": "chromatic --exit-zero-on-changes --skip 'dependabot/**'",
     "test:jest": "jest",
     "test:jest-watch": "jest --watch",
-    "test:e2e": "env-cmd -f .env synpress run"
+    "test:e2e": "env-cmd -f .env synpress run",
+    "prepare": "husky install",
+    "lint:w": "eslint --fix '**/*.{js,jsx,ts,tsx,json,md}'",
+    "lint": "eslint '**/*.{js,jsx,ts,tsx,json,md}'"
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx,json,md}": [
+      "eslint --fix"
+    ]
   },
   "version": "0.1.0"
 }

--- a/apps/council-frontend/src/ui/app/Sidebar.tsx
+++ b/apps/council-frontend/src/ui/app/Sidebar.tsx
@@ -69,7 +69,7 @@ export default function Sidebar(props: SidebarProps): ReactElement {
               label={t`Overview`}
               router={router}
               icon={
-                <HomeIcon className="text-principalRoyalBlue h-4 w-4 flex-shrink-0" />
+                <HomeIcon className="text-principalRoyalBlue h-4 w-4 shrink-0" />
               }
             />
             <SidebarLink
@@ -77,7 +77,7 @@ export default function Sidebar(props: SidebarProps): ReactElement {
               label={t`Proposals`}
               router={router}
               icon={
-                <PencilAltIcon className="text-principalRoyalBlue h-4 w-4 flex-shrink-0" />
+                <PencilAltIcon className="text-principalRoyalBlue h-4 w-4 shrink-0" />
               }
             />
             <SidebarLink
@@ -85,7 +85,7 @@ export default function Sidebar(props: SidebarProps): ReactElement {
               label={t`Delegate`}
               router={router}
               icon={
-                <UserGroupIcon className="text-principalRoyalBlue h-4 w-4 flex-shrink-0" />
+                <UserGroupIcon className="text-principalRoyalBlue h-4 w-4 shrink-0" />
               }
             />
             <SidebarLink
@@ -93,7 +93,7 @@ export default function Sidebar(props: SidebarProps): ReactElement {
               label={t`GSC`}
               router={router}
               icon={
-                <LibraryIcon className="text-principalRoyalBlue h-4 w-4 flex-shrink-0" />
+                <LibraryIcon className="text-principalRoyalBlue h-4 w-4 shrink-0" />
               }
             />
             <SidebarLinkExternal link={ElementUrl.FORUM} label={t`Forum`} />
@@ -178,7 +178,7 @@ function SidebarLinkExternal(props: SidebarLinkExternalProps): ReactElement {
         className=" hover:bg-blue-50 md:w-full"
       >
         <div className="text-brandDarkBlue-dark flex cursor-pointer items-center justify-start gap-2 px-2 py-3 md:relative md:left-[50%] md:translate-x-[-25%]">
-          <ExternalLinkIcon className="text-principalRoyalBlue h-4 w-4 flex-shrink-0" />
+          <ExternalLinkIcon className="text-principalRoyalBlue h-4 w-4 shrink-0" />
           <p>{label}</p>
         </div>
       </a>

--- a/apps/council-frontend/src/ui/base/Dialog/Dialog.example.tsx
+++ b/apps/council-frontend/src/ui/base/Dialog/Dialog.example.tsx
@@ -45,7 +45,7 @@ export default function ExampleDialog(props: ExampleDialogProps): ReactElement {
             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
-            <div className="inline-block transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 sm:align-middle">
+            <div className="inline-block overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6 sm:align-middle">
               <div>
                 <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100"></div>
                 <div className="mt-3 text-center sm:mt-5">

--- a/apps/council-frontend/src/ui/base/ExternalLink/ExternalLink.tsx
+++ b/apps/council-frontend/src/ui/base/ExternalLink/ExternalLink.tsx
@@ -26,7 +26,7 @@ function ExternalLink({
     >
       {text ?? children}
       {showIcon && (
-        <ExternalLinkIcon className="h-4 w-4 flex-shrink-0 text-current" />
+        <ExternalLinkIcon className="h-4 w-4 shrink-0 text-current" />
       )}
     </a>
   );

--- a/apps/council-frontend/src/ui/delegate/DelegatesList/DelegateProfileRow.tsx
+++ b/apps/council-frontend/src/ui/delegate/DelegatesList/DelegateProfileRow.tsx
@@ -146,7 +146,7 @@ function DelegateProfileRow(props: DelegateProfileRowProps): ReactElement {
         >
           <Popover.Panel
             className="bg-hackerSky fixed inset-0 z-20 box-content sm:inset-[initial] sm:top-[50%] sm:left-[50%] sm:w-[400px] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-xl md:w-[700px]
-          lg:absolute lg:top-0 lg:inset-x-0 lg:h-full lg:w-full lg:translate-x-0 lg:translate-y-0"
+          lg:absolute lg:inset-x-0 lg:top-0 lg:h-full lg:w-full lg:translate-x-0 lg:translate-y-0"
           >
             {({ close }) => (
               <DetailedDelegateProfile

--- a/apps/council-frontend/src/ui/delegate/DelegatesList/DelegateProfileRow.tsx
+++ b/apps/council-frontend/src/ui/delegate/DelegatesList/DelegateProfileRow.tsx
@@ -145,8 +145,8 @@ function DelegateProfileRow(props: DelegateProfileRowProps): ReactElement {
           leaveTo="opacity-0 sm:scale-95"
         >
           <Popover.Panel
-            className="bg-hackerSky fixed inset-0 z-20 box-content sm:inset-[initial] sm:top-[50%] sm:left-[50%] sm:w-[400px] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:transform sm:rounded-xl
-          md:w-[700px] lg:absolute lg:top-0 lg:right-0 lg:left-0 lg:h-full lg:w-full lg:translate-x-0 lg:translate-y-0"
+            className="bg-hackerSky fixed inset-0 z-20 box-content sm:inset-[initial] sm:top-[50%] sm:left-[50%] sm:w-[400px] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-xl md:w-[700px]
+          lg:absolute lg:top-0 lg:inset-x-0 lg:h-full lg:w-full lg:translate-x-0 lg:translate-y-0"
           >
             {({ close }) => (
               <DetailedDelegateProfile

--- a/apps/council-frontend/src/ui/gsc/GSCOverviewSection.tsx
+++ b/apps/council-frontend/src/ui/gsc/GSCOverviewSection.tsx
@@ -128,7 +128,7 @@ export function GSCOverviewSection(): ReactElement {
               <Disclosure as="div">
                 {({ open }) => (
                   <>
-                    <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg px-4 py-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
+                    <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg p-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
                       <span>{t`What makes someone eligible to join the GSC?`}</span>
 
                       <ChevronDownIcon
@@ -157,7 +157,7 @@ export function GSCOverviewSection(): ReactElement {
               <Disclosure as="div" className="mt-4">
                 {({ open }) => (
                   <>
-                    <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg px-4 py-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
+                    <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg p-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
                       <span>{t`What are the day-to-day responsibilities of a GSC member?`}</span>
 
                       <ChevronDownIcon
@@ -187,7 +187,7 @@ export function GSCOverviewSection(): ReactElement {
               <Disclosure as="div" className="mt-4">
                 {({ open }) => (
                   <>
-                    <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg px-4 py-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
+                    <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg p-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
                       <span>{t`How are GSC members removed and/or added?`}</span>
 
                       <ChevronDownIcon

--- a/apps/council-frontend/src/ui/gsc/GSCPortfolioCard.tsx
+++ b/apps/council-frontend/src/ui/gsc/GSCPortfolioCard.tsx
@@ -49,7 +49,7 @@ export function GSCPortfolioCard({
         )}
       </div>
 
-      <div className="mt-4 mb-4 flex min-h-full min-w-fit flex-row flex-wrap items-center space-y-6 xl:space-y-0">
+      <div className="my-4 flex min-h-full min-w-fit flex-row flex-wrap items-center space-y-6 xl:space-y-0">
         {/* GSC eligibility progress bar */}
         <div className="flex grow-[2] basis-[34rem] flex-wrap md:flex-nowrap lg:space-y-0">
           {/* Voting Power */}

--- a/apps/council-frontend/src/ui/landing/LandingPage.tsx
+++ b/apps/council-frontend/src/ui/landing/LandingPage.tsx
@@ -16,7 +16,7 @@ export default function LandingPage(): ReactElement {
   return (
     // outer element is set to overflow: hidden to hide the overflowing
     // background glows
-    <div className="bg-principalRoyalBlue absolute top-0 left-0 right-0 bottom-0 overflow-hidden text-white">
+    <div className="bg-principalRoyalBlue absolute inset-0 overflow-hidden text-white">
       <Head>
         <title>{t`Welcome | Element Council Protocol`}</title>
         {/* TODO: Update to a favicon with a transparent background */}

--- a/apps/council-frontend/src/ui/overview/OverviewPage.tsx
+++ b/apps/council-frontend/src/ui/overview/OverviewPage.tsx
@@ -77,7 +77,7 @@ function FAQ() {
           <Disclosure as="div" className="mt-2">
             {({ open }) => (
               <>
-                <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg px-4 py-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
+                <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg p-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
                   <span>{t`What is Element Council?`}</span>
 
                   <ChevronDownIcon
@@ -99,7 +99,7 @@ function FAQ() {
           <Disclosure as="div" className="mt-2">
             {({ open }) => (
               <>
-                <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg px-4 py-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
+                <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg p-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
                   <span>{t`What is a voting vault?`}</span>
                   <ChevronDownIcon
                     className={classNames(
@@ -127,7 +127,7 @@ function FAQ() {
           <Disclosure as="div" className="mt-2">
             {({ open }) => (
               <>
-                <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg px-4 py-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
+                <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg p-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
                   <span>{t`How does delegated voting work?`}</span>
                   <ChevronDownIcon
                     className={classNames(
@@ -147,7 +147,7 @@ function FAQ() {
           <Disclosure as="div" className="mt-2">
             {({ open }) => (
               <>
-                <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg px-4 py-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
+                <Disclosure.Button className="bg-hackerSky text-principalRoyalBlue hover:bg-hackerSky-dark flex w-full justify-between rounded-lg p-4 text-left text-sm font-medium focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75">
                   <span>{t`Who are the GSC (Governance Steering Council)?`}</span>
                   <ChevronDownIcon
                     className={classNames(

--- a/apps/council-frontend/src/ui/proposals/ProposalsDetailsCard/GSCMember.tsx
+++ b/apps/council-frontend/src/ui/proposals/ProposalsDetailsCard/GSCMember.tsx
@@ -17,7 +17,7 @@ export function GSCMember(props: GSCMemberProps): ReactElement {
     <Button variant={ButtonVariant.OUTLINE_WHITE}>
       <div className="flex w-full items-center overflow-hidden">
         <WalletJazzicon size={28} account={account} className="mr-4" />
-        <div className="max-w-0 flex-shrink text-sm font-thin">
+        <div className="max-w-0 shrink text-sm font-thin">
           {formattedAddress}
         </div>
       </div>

--- a/apps/council-frontend/src/ui/zk/EncryptionCard/HashSlider.tsx
+++ b/apps/council-frontend/src/ui/zk/EncryptionCard/HashSlider.tsx
@@ -227,7 +227,7 @@ export default function HashSlider({
               ))}
             </div>
             <Tooltip
-              className="absolute left-0 right-0 -top-3"
+              className="absolute inset-x-0 -top-3"
               content={t`Keep sliding`}
               isOpen={showTooltip}
             >

--- a/apps/council-frontend/src/ui/zk/IntroCard.tsx
+++ b/apps/council-frontend/src/ui/zk/IntroCard.tsx
@@ -35,7 +35,7 @@ export default function IntroCard({
         <h1 className="mb-4 text-4xl font-semibold text-white">{t`${platformName} Airdrop`}</h1>
         <p>{jt`This airdrop utilizes a method named Zero Knowledge Proof that allows you to claim participation in the governance system based on your ${platformName} ID without revealing any personal information. You can ${learnMoreHereLink}.`}</p>
         <H2 className="mt-4 text-2xl text-white">{t`How does it work?`}</H2>
-        <div className="mt-6 mb-6 flex flex-col gap-2 rounded-lg bg-white/10 px-5 py-4 sm:py-6 sm:px-8">
+        <div className="my-6 flex flex-col gap-2 rounded-lg bg-white/10 px-5 py-4 sm:py-6 sm:px-8">
           <H3 className="text-white">{t`1. Generate your Key, Secret, & Public ID.`}</H3>
           <p>{t`Use your cursor to randomly generate a new Key and Secret pair which you'll download for later use, then get a Public ID derived from your Key and Secret.`}</p>
           <H3 className="mt-4 text-white">{t`2. Share your new Public ID on ${platformName}.`}</H3>

--- a/apps/council-frontend/tests/e2e/.eslintrc.js
+++ b/apps/council-frontend/tests/e2e/.eslintrc.js
@@ -1,7 +1,19 @@
 const path = require("path");
+
+/**
+ * process.cwd() (Current Working Directory)
+ * Returns a different path depending on where the script that calls it is ran from
+ *
+ * This is a solution for when the script is in the council-frontend or root dir
+ */
+let ROOT_PATH = process.cwd().slice(0, process.cwd().indexOf("/apps"));
+if (ROOT_PATH.charAt(ROOT_PATH.length - 1) !== "o") {
+  ROOT_PATH += "o";
+}
+
 const synpressPath = path.join(
   // Hacky way to get the absolute project root path
-  process.cwd().slice(0, process.cwd().indexOf("/apps")),
+  ROOT_PATH,
   "/node_modules/@synthetixio/synpress",
 );
 

--- a/apps/council-frontend/tests/e2e/.eslintrc.js
+++ b/apps/council-frontend/tests/e2e/.eslintrc.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const synpressPath = path.join(
-  process.cwd(),
+  // Hacky way to get the absolute project root path
+  process.cwd().slice(0, process.cwd().indexOf("/apps")),
   "/node_modules/@synthetixio/synpress",
 );
 

--- a/apps/council-frontend/tests/e2e/.eslintrc.js
+++ b/apps/council-frontend/tests/e2e/.eslintrc.js
@@ -1,6 +1,8 @@
 const path = require("path");
 
 /**
+ * Hacky way to get the absolute project root path:
+ *
  * process.cwd() (Current Working Directory)
  * Returns a different path depending on where the script that calls it is ran from
  *
@@ -12,7 +14,6 @@ if (ROOT_PATH.charAt(ROOT_PATH.length - 1) !== "o") {
 }
 
 const synpressPath = path.join(
-  // Hacky way to get the absolute project root path
   ROOT_PATH,
   "/node_modules/@synthetixio/synpress",
 );

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "packages/council-typechain/dist",
     "packages/core-typechain/dist",
     "packages/core-tokenlist/dist",
-    "packages/council-tokenlist/dist"
+    "packages/council-tokenlist/dist",
+    "packages/council-proposals/compiled"
   ],
   "scripts": {
     "prepare": "husky install",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -7,6 +7,7 @@ module.exports = {
     "plugin:testing-library/react",
     "plugin:jest-dom/recommended",
     "plugin:jsx-a11y/recommended",
+    "plugin:tailwindcss/recommended",
     "prettier",
   ],
   plugins: ["tailwindcss", "jsx-a11y", "testing-library", "jest-dom"],
@@ -20,6 +21,7 @@ module.exports = {
     },
   ],
   rules: {
+    "tailwindcss/classnames-order": "off",
     "@typescript-eslint/semi": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error", // exported functions must have return types
     "@typescript-eslint/no-empty-function": "off", // empty arrow functions are fine for noops when passed to components

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -29,7 +29,6 @@ module.exports = {
   ],
   rules: {
     "tailwindcss/classnames-order": "off", // Disable ordering in favor of prettier plugin
-    "@typescript-eslint/semi": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error", // exported functions must have return types
     "@typescript-eslint/no-empty-function": "off", // empty arrow functions are fine for noops when passed to components
     "@typescript-eslint/no-empty-interface": "off", // empty interfaces for component props should be allowed

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -8,6 +8,13 @@ module.exports = {
     "plugin:jest-dom/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:tailwindcss/recommended",
+    /**
+     * Prettier must be the last extension in the list.
+     * Prettier works best if you disable all other ESLint rules relating to
+     * code formatting, and only enable rules that detect potential bugs.
+     * (If another active ESLint rule disagrees with prettier about how code
+     * should be formatted, it will be impossible to avoid lint errors.)
+     */
     "prettier",
   ],
   plugins: ["tailwindcss", "jsx-a11y", "testing-library", "jest-dom"],
@@ -21,7 +28,7 @@ module.exports = {
     },
   ],
   rules: {
-    "tailwindcss/classnames-order": "off",
+    "tailwindcss/classnames-order": "off", // Disable ordering in favor of prettier plugin
     "@typescript-eslint/semi": "error",
     "@typescript-eslint/explicit-module-boundary-types": "error", // exported functions must have return types
     "@typescript-eslint/no-empty-function": "off", // empty arrow functions are fine for noops when passed to components


### PR DESCRIPTION
This PR adds `eslint` to the `council-frontend` app. In addition, it seemed like we weren't utilizing `eslint-plugin-tailwindcss` rules and so I extended the recommended rules within the base `eslint` config and ran the new linter scripts within `council-frontend` for some clean-up. Opted to disable the `tailwind/classnames-order` rule because we already have a set order for that and the `eslint-plugin-tailwindcss` ordering rules aren't official. 

I also verified that the pre-commit was working correctly and was reading correctly from the `council-frontend/.eslintrc` file by adding errors to certain rules and committing bad commits.

One caveat, needed to override the `no-var-requires` rule for the `.eslintrc` file within `tests/e2e`, because it requires the use of the `path` module in order to get the absolute path for the root of the project in order to extend synpress' `.eslintrc`.

