### PR TITLE
[council-sdk] Add functions to calculate rewards for holders of an ERC20

### DIFF
--- a/packages/council-sdk/src/IPFSData.ts
+++ b/packages/council-sdk/src/IPFSData.ts
@@ -1,0 +1,46 @@
+// Example:
+// const ipfsFormat = {
+//   block: 1234567,
+//   leaves: [
+//     {
+//       address: "0xASDF...ASDF",
+//       balances: [
+//         { tokenAddress: "0xASDF...ASDF", balance: "100", "rewards": "1"},
+//         { tokenAddress: "0xASDF...ASDF", balance: undefined, rewards: undefined }
+//       ]
+//     },
+//   ];
+// }
+
+export interface IPFSData {
+  block: number;
+  leaves: Leaf[];
+}
+
+export interface Leaf {
+  /**
+   * hexadecimal ethereum address
+   */
+  address: string;
+  /**
+   * list of balances and rewards for each token the
+   */
+  data: LeafData[];
+}
+
+export interface LeafData {
+  /**
+   * hexadecimal ethereum address
+   */
+  tokenAddress: string;
+
+  /**
+   * whole number value in the token's atomic unit.  i.e. 1 WETH would be "1000000000000000000".
+   */
+  balance: string | undefined;
+
+  /**
+   * whole number value for the running total amount of rewards the account has accrued.
+   */
+  rewards: string | undefined;
+}

--- a/packages/council-sdk/src/ValueChange.ts
+++ b/packages/council-sdk/src/ValueChange.ts
@@ -1,0 +1,10 @@
+/**
+ * The amount and timestamp when the value changes
+ */
+export interface ValueChange {
+  // when the value change occured, could be a timestamp or blocknumber
+  at: number;
+
+  // the amount the value changed by, either positive or negative
+  valueChange: bigint;
+}

--- a/packages/council-sdk/src/ValueOverPeriod.ts
+++ b/packages/council-sdk/src/ValueOverPeriod.ts
@@ -1,0 +1,9 @@
+/**
+ * A value for a given amount of time
+ */
+
+export interface ValueOverPeriod {
+  value: bigint;
+  start: number;
+  end: number;
+}

--- a/packages/council-sdk/src/calculateTimeWeightedValue.test.ts
+++ b/packages/council-sdk/src/calculateTimeWeightedValue.test.ts
@@ -1,0 +1,131 @@
+import { ValueOverPeriod } from "src/ValueOverPeriod";
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { formatEther, parseEther } from "ethers/lib/utils";
+
+import { calculateTimeWeightedValue } from "./calculateTimeWeightedValue";
+
+describe("calculateTimeWeightedValue", () => {
+  it("Should time weight with no changes in value", async () => {
+    const valueBlocks: ValueOverPeriod[] = [
+      {
+        value: BigInt(1),
+        start: 0,
+        end: 100,
+      },
+    ];
+    const startBlock = 0;
+    const endBlock = 100;
+
+    const result = calculateTimeWeightedValue(
+      valueBlocks,
+      startBlock,
+      endBlock,
+    );
+
+    expect(result).to.equal(BigInt(1));
+  });
+  it("Should time weight with one value change", async () => {
+    const valueBlocks: ValueOverPeriod[] = [
+      {
+        value: BigInt(0),
+        start: 0,
+        end: 50,
+      },
+      {
+        value: BigInt(2),
+        start: 50,
+        end: 100,
+      },
+    ];
+    const startBlock = 0;
+    const endBlock = 100;
+
+    const result = calculateTimeWeightedValue(
+      valueBlocks,
+      startBlock,
+      endBlock,
+    );
+
+    // value changes once from 0 to 2 in the middle of the period, the average should be half
+    expect(result).to.equal(BigInt(1));
+  });
+
+  it("Should time weight with many value changes", async () => {
+    const valueBlocks: ValueOverPeriod[] = [
+      {
+        value: BigInt(0),
+        start: 0,
+        end: 25,
+      },
+      {
+        value: BigInt(10),
+        start: 25,
+        end: 50,
+      },
+      {
+        value: BigInt(20),
+        start: 50,
+        end: 75,
+      },
+      {
+        value: BigInt(30),
+        start: 75,
+        end: 100,
+      },
+    ];
+    const startBlock = 0;
+    const endBlock = 100;
+
+    const result = calculateTimeWeightedValue(
+      valueBlocks,
+      startBlock,
+      endBlock,
+    );
+
+    // the value increases by 10 each time, each period is 25s, the total period is 100s
+    // (0 + 10 + 20 + 30) * 25 / 100 = 15
+    expect(result).to.equal(BigInt(15));
+  });
+
+  it("Should time weight with more realistic values", async () => {
+    const startBlock = 12345678;
+    const ONE_DAY_IN_BLOCKS = 6496; // 86400 second / ~13.3 blocks/second
+    const endBlock = startBlock + 4 * ONE_DAY_IN_BLOCKS;
+    const ONE_ETH = BigInt(parseEther("1").toString());
+
+    // add one ETH every day
+    const valueBlocks: ValueOverPeriod[] = [
+      {
+        value: BigInt(0),
+        start: startBlock,
+        end: startBlock + ONE_DAY_IN_BLOCKS * 1,
+      },
+      {
+        value: BigInt(1) * ONE_ETH,
+        start: startBlock + ONE_DAY_IN_BLOCKS * 1,
+        end: startBlock + ONE_DAY_IN_BLOCKS * 2,
+      },
+      {
+        value: BigInt(2) * ONE_ETH,
+        start: startBlock + ONE_DAY_IN_BLOCKS * 2,
+        end: startBlock + ONE_DAY_IN_BLOCKS * 3,
+      },
+      {
+        value: BigInt(3) * ONE_ETH,
+        start: startBlock + ONE_DAY_IN_BLOCKS * 3,
+        end: endBlock,
+      },
+    ];
+
+    const result = calculateTimeWeightedValue(
+      valueBlocks,
+      startBlock,
+      endBlock,
+    );
+
+    // the value increases by 1 ETH each time, each period is 1 day, the total period is 4 days
+    // (0 + 1 + 2 + 3) * 1 day / 4 days = 1.5
+    expect(formatEther(BigNumber.from(result.toString()))).to.equal("1.5");
+  });
+});

--- a/packages/council-sdk/src/calculateTimeWeightedValue.ts
+++ b/packages/council-sdk/src/calculateTimeWeightedValue.ts
@@ -1,0 +1,26 @@
+import { ValueOverPeriod } from "src/ValueOverPeriod";
+
+/**
+ * Calculates a time-weighted value for an asset over a given window of time.
+ * @param startingValue the starting value to weight over time, if any
+ * @param valueChanges an array of objects that contain the amount transferred and when.
+ * @param startBlock the eth block beginning the period for the weighted value.  timestamp in whole seconds.
+ * must come before first value change.
+ * @param endBlock the eth block ending the period for the weighted value.  timestamp in whole seconds.  must
+ * come after last value change.
+ */
+export function calculateTimeWeightedValue(
+  valueTimeBlocks: ValueOverPeriod[],
+  startBlock: number,
+  endBlock: number,
+): bigint {
+  let total = BigInt(0);
+  valueTimeBlocks.forEach(({ value, start: valueStart, end: valueEnd }) => {
+    const time = BigInt(valueEnd - valueStart);
+    total += value * time;
+  });
+
+  const timeWeightedValue = total / BigInt(endBlock - startBlock);
+
+  return timeWeightedValue;
+}

--- a/packages/council-sdk/src/convertValueChangesToBalances.ts
+++ b/packages/council-sdk/src/convertValueChangesToBalances.ts
@@ -1,0 +1,87 @@
+import { ValueChange } from "src/ValueChange";
+import { ValueOverPeriod } from "src/ValueOverPeriod";
+
+/**
+ * Converts from value changes to balances for all accounts for a given block period.
+ * @param balancesAtStartBlockByAddress starting balances keyed by address
+ * @param valueChangesByAddress value changes keyed by address
+ * @param startBlock starting block of the period
+ * @param endBlock ending block of the period
+ * @returns an object of arrays of ValueOverPeriod's keyed by address
+ */
+export function convertValueChangesToBalancesForAllAccounts(
+  balancesAtStartBlockByAddress: Record<string, bigint>,
+  valueChangesByAddress: Record<string, ValueChange[]>,
+  startBlock: number,
+  endBlock: number,
+): Record<string, ValueOverPeriod[]> {
+  const balancesOverPeriod: Record<string, ValueOverPeriod[]> = {};
+
+  for (const address in balancesAtStartBlockByAddress) {
+    const valueChanges = valueChangesByAddress[address];
+
+    // if there are no value changes, then obviously we just return the balance over the whole period
+    if (!valueChanges) {
+      balancesOverPeriod[address] = [
+        {
+          start: startBlock,
+          end: endBlock,
+          value: balancesAtStartBlockByAddress[address],
+        },
+      ];
+      // otherwise, we need to convert value changes to balances
+    } else {
+      const startingBalance = balancesAtStartBlockByAddress[address];
+      const balancesOverPeriodForUser = convertValueChangesToBalances(
+        valueChanges,
+        startingBalance,
+        startBlock,
+        endBlock,
+      );
+      balancesOverPeriod[address] = balancesOverPeriodForUser;
+    }
+  }
+
+  return balancesOverPeriod;
+}
+
+/**
+ * Converts from value changes (either increments or decrements) to values over time.  For example,
+ * if there were 4 values changes +1, +1, -1, 1 with starting value of zero, we'd get back values
+ * like 0, 1, 2, 1, 0.
+ * @param valueChanges an array of incremental changes at blockstamps
+ * @param startingBalance the starting value
+ * @param startBlock
+ * @param endBlock
+ * @returns {ValueOverPeriod[]} An array of values and their block periods
+ */
+function convertValueChangesToBalances(
+  valueChanges: ValueChange[],
+  startingBalance: bigint,
+  startBlock: number,
+  endBlock: number,
+): ValueOverPeriod[] {
+  const balanceTimeBlocks: ValueOverPeriod[] = [];
+
+  let balance = startingBalance;
+  let start = startBlock;
+
+  valueChanges.forEach(({ at, valueChange }) => {
+    balanceTimeBlocks.push({
+      value: balance,
+      start,
+      end: at,
+    });
+
+    balance = valueChange + balance;
+    start = at;
+  });
+
+  balanceTimeBlocks.push({
+    value: balance,
+    start,
+    end: endBlock,
+  });
+
+  return balanceTimeBlocks;
+}

--- a/packages/council-sdk/src/examples/calculateRewards.test.ts
+++ b/packages/council-sdk/src/examples/calculateRewards.test.ts
@@ -1,0 +1,179 @@
+import { MockERC20, MockERC20__factory } from "@elementfi/council-typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { formatUnits, parseEther, parseUnits } from "ethers/lib/utils";
+import hre, { waffle } from "hardhat";
+
+import { fetchValueChangesForERC20 } from "src/fetchValueChangesForERC20";
+import { mineBlocks } from "src/test/mineBlocks";
+import { createSnapshot, restoreSnapshot } from "src/test/snapshot";
+import { calculateRewards } from "src/examples/calculateRewards";
+
+const { provider } = waffle;
+
+const ONE_ETH = BigInt(parseEther("1").toString());
+
+const WBTC_DECIMALS = 8;
+const ONE_WBTC = BigInt(parseUnits("1", WBTC_DECIMALS).toString());
+
+describe("calculateRewards", () => {
+  let signers: SignerWithAddress[];
+  let deployer: SignerWithAddress;
+  let signer1: SignerWithAddress;
+  let signer2: SignerWithAddress;
+  let signer3: SignerWithAddress;
+  let tokenContract: MockERC20;
+
+  before(async () => {
+    // create snapshot of initial testnet at block 0
+    await createSnapshot(provider);
+
+    signers = await hre.ethers.getSigners();
+    [deployer, signer1, signer2, signer3] = signers;
+
+    // deployed in block 1
+    tokenContract = await deployERC20(deployer);
+  });
+
+  beforeEach(async () => {
+    await createSnapshot(provider);
+  });
+  afterEach(async () => {
+    await restoreSnapshot(provider);
+  });
+
+  after(async () => {
+    // restore snapshot to empty testnet
+    await restoreSnapshot(provider);
+  });
+
+  it("should distribute rewards evenly for accounts", async () => {
+    const balancesAtStartBlock = {
+      [signer1.address]: ONE_ETH,
+      [signer2.address]: ONE_ETH,
+      [signer3.address]: ONE_ETH,
+    };
+
+    const signers1to3 = signers.slice(1, 4);
+
+    // creates Transfer events in blocks 2-4, mints come from address zero.
+    for (const signer of signers1to3) {
+      await tokenContract.mint(signer.address, parseEther("10"));
+    }
+
+    // blocks 5 - 9
+    await mineBlocks(5, provider);
+
+    const startBlock = 5;
+    const endBlock = 9;
+    const rewardsForPeriod = ONE_WBTC;
+
+    // there are no value changes in blocks 5-9, each user has 1 ETH the whole time
+    const valueChanges = await fetchValueChangesForERC20(
+      tokenContract.address,
+      startBlock,
+      endBlock,
+      provider,
+    );
+
+    // we *should* see an even distribution for all users, since the reward for this period is 1
+    // WBTC and we have 3 users, they should receive 1/3 WBTC each.
+    const rewardsPerUser = calculateRewards(
+      balancesAtStartBlock,
+      valueChanges,
+      startBlock,
+      endBlock,
+      rewardsForPeriod,
+    );
+
+    signers1to3.forEach((signer) => {
+      const reward = formatUnits(
+        rewardsPerUser[signer.address].toString(),
+        WBTC_DECIMALS,
+      );
+      expect(reward).to.equal("0.33333333");
+    });
+  });
+
+  it("should distribute rewards proportinally for accounts", async () => {
+    const signers1to3 = signers.slice(1, 4);
+
+    // creates Transfer events in blocks 2-4, mints come from address zero.
+    for (const signer of signers1to3) {
+      await tokenContract.mint(signer.address, parseEther("10"));
+    }
+
+    // we'll checking rewards at block 5, so all accounts have a starting value of 10 ETH
+    const balancesAtStartBlock = {
+      [signer1.address]: ONE_ETH * BigInt(10),
+      [signer2.address]: ONE_ETH * BigInt(10),
+      [signer3.address]: ONE_ETH * BigInt(10),
+    };
+
+    const block = await provider.getBlockNumber();
+    expect(block).to.equal(4);
+
+    // block 5
+    await mineBlocks(1, provider);
+    // block 6
+    await tokenContract.mint(signer1.address, parseEther("20"));
+    // block 7
+    await mineBlocks(1, provider);
+
+    const startBlock = 5;
+    const endBlock = 7;
+    const rewardsForPeriod = ONE_WBTC;
+
+    // signer 1 increases from 10 to 30 for an average of 20.  signer 2 and 3 have 10 the whole time.
+    const valueChanges = await fetchValueChangesForERC20(
+      tokenContract.address,
+      startBlock,
+      endBlock,
+      provider,
+    );
+
+    // signer 1 average: 20 ETH
+    // signer 2 average: 10 ETH
+    // signer 3 average: 10 ETH
+    // signer1  has an average of half the tokens (20/40 ETH), signer 2 and 3 have and average of one quarter
+    // the tokens each. (10/40 ETH)
+    const rewardsPerUser = calculateRewards(
+      balancesAtStartBlock,
+      valueChanges,
+      startBlock,
+      endBlock,
+      rewardsForPeriod,
+    );
+
+    const signer1Reward = formatUnits(
+      rewardsPerUser[signer1.address].toString(),
+      WBTC_DECIMALS,
+    );
+    expect(signer1Reward).to.equal("0.5");
+
+    const signer2Reward = formatUnits(
+      rewardsPerUser[signer2.address].toString(),
+      WBTC_DECIMALS,
+    );
+    expect(signer2Reward).to.equal("0.25");
+
+    const signer3Reward = formatUnits(
+      rewardsPerUser[signer3.address].toString(),
+      WBTC_DECIMALS,
+    );
+    expect(signer3Reward).to.equal("0.25");
+  });
+});
+
+export async function deployERC20(
+  signer: SignerWithAddress,
+): Promise<MockERC20> {
+  const tokenDeployer = new MockERC20__factory(signer);
+  const tokenContract = await tokenDeployer.deploy(
+    "Mock ERC20",
+    "MERC",
+    signer.address,
+  );
+
+  return tokenContract;
+}

--- a/packages/council-sdk/src/examples/calculateRewards.ts
+++ b/packages/council-sdk/src/examples/calculateRewards.ts
@@ -1,0 +1,41 @@
+import { ValueChange } from "src/ValueChange";
+import { calculateTimeWeightedValue } from "src/calculateTimeWeightedValue";
+import { convertValueChangesToBalancesForAllAccounts } from "src/convertValueChangesToBalances";
+
+export function calculateRewards(
+  balancesAtStartBlock: Record<string, bigint>,
+  valueChanges: Record<string, ValueChange[]>,
+  startBlock: number,
+  endBlock: number,
+  rewardsForPeriod: bigint,
+): Record<string, bigint> {
+  const balancesByAddress = convertValueChangesToBalancesForAllAccounts(
+    balancesAtStartBlock,
+    valueChanges,
+    startBlock,
+    endBlock,
+  );
+
+  const balanceAveragesByAddress: Record<string, bigint> = {};
+  let total = BigInt(0);
+
+  for (const address in balancesByAddress) {
+    const balances = balancesByAddress[address];
+    const timeWeightedAverage = calculateTimeWeightedValue(
+      balances,
+      startBlock,
+      endBlock,
+    );
+
+    balanceAveragesByAddress[address] = timeWeightedAverage;
+    total += timeWeightedAverage;
+  }
+
+  const rewardsPerAddress: Record<string, bigint> = {};
+  for (const address in balanceAveragesByAddress) {
+    rewardsPerAddress[address] =
+      (balanceAveragesByAddress[address] * rewardsForPeriod) / total;
+  }
+
+  return rewardsPerAddress;
+}

--- a/packages/council-sdk/src/fetchIPFSData.ts
+++ b/packages/council-sdk/src/fetchIPFSData.ts
@@ -1,0 +1,8 @@
+import { IPFSData } from "./IPFSData";
+const IPFS_BASE_URL = "https://ipfs.io/ipfs/";
+
+export async function fetchIPFSData(ipfsHash: string): Promise<IPFSData> {
+  const response = await fetch(`${IPFS_BASE_URL}${ipfsHash}`);
+  const data = await response.json();
+  return data as IPFSData;
+}

--- a/packages/council-sdk/src/fetchValueChangesForERC20.test.ts
+++ b/packages/council-sdk/src/fetchValueChangesForERC20.test.ts
@@ -1,0 +1,208 @@
+import { constants } from "ethers";
+import { MockERC20, MockERC20__factory } from "@elementfi/council-typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { parseEther } from "ethers/lib/utils";
+import hre, { waffle } from "hardhat";
+
+import { fetchValueChangesForERC20 } from "src/fetchValueChangesForERC20";
+import { mineBlocks } from "src/test/mineBlocks";
+import { createSnapshot, restoreSnapshot } from "src/test/snapshot";
+
+const { provider } = waffle;
+
+describe("fetchValueChangesForERC20", () => {
+  let signers: SignerWithAddress[];
+  let deployer: SignerWithAddress;
+  let signer1: SignerWithAddress;
+  let signer2: SignerWithAddress;
+  let tokenContract: MockERC20;
+
+  before(async () => {
+    // create snapshot of initial testnet at block 0
+    await createSnapshot(provider);
+
+    signers = await hre.ethers.getSigners();
+    [deployer, signer1, signer2] = signers;
+
+    tokenContract = await deployERC20(deployer);
+  });
+
+  beforeEach(async () => {
+    await createSnapshot(provider);
+  });
+  afterEach(async () => {
+    await restoreSnapshot(provider);
+  });
+
+  after(async () => {
+    // restore snapshot to empty testnet
+    await restoreSnapshot(provider);
+  });
+
+  it("should return an ampty object if no value changes found", async () => {
+    await mineBlocks(5, provider);
+
+    const startBlock = 0;
+    const endBlock = await provider.getBlockNumber();
+    const valueChanges = await fetchValueChangesForERC20(
+      tokenContract.address,
+      startBlock,
+      endBlock,
+      provider,
+    );
+
+    expect(valueChanges).to.deep.equal({});
+  });
+
+  it("should fetch value changes for all holders, ignoring the zero address and token address", async () => {
+    const signers1to5 = signers.slice(1, 6);
+
+    // creates Transfer events in blocks 2-6, mints come from address zero.
+    for (const signer of signers1to5) {
+      await tokenContract.mint(signer.address, parseEther("10"));
+    }
+
+    const startBlock = 0;
+    const endBlock = await provider.getBlockNumber();
+    const valueChanges = await fetchValueChangesForERC20(
+      tokenContract.address,
+      startBlock,
+      endBlock,
+      provider,
+    );
+
+    expect(valueChanges).to.deep.equal({
+      "0x70997970C51812dc3A010C7d01b50e0d17dc79C8": [
+        { valueChange: 10000000000000000000n, at: 2 },
+      ],
+      "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC": [
+        { valueChange: 10000000000000000000n, at: 3 },
+      ],
+      "0x90F79bf6EB2c4f870365E785982E1f101E93b906": [
+        { valueChange: 10000000000000000000n, at: 4 },
+      ],
+      "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65": [
+        { valueChange: 10000000000000000000n, at: 5 },
+      ],
+      "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc": [
+        { valueChange: 10000000000000000000n, at: 6 },
+      ],
+    });
+
+    expect(valueChanges[constants.AddressZero]).to.equal(undefined);
+  });
+
+  it("should only fetch value changes in range", async () => {
+    const signers1to5 = signers.slice(1, 6);
+
+    // creates Transfer events in blocks 2-6
+    for (const signer of signers1to5) {
+      await tokenContract.mint(signer.address, parseEther("10"));
+    }
+
+    // ignore value changes at blocks 2 and 6
+    const startBlock = 3;
+    const endBlock = 5;
+    const valueChanges = await fetchValueChangesForERC20(
+      tokenContract.address,
+      startBlock,
+      endBlock,
+      provider,
+    );
+
+    const signers2to4 = signers.slice(2, 5);
+    signers2to4.forEach(({ address }) => {
+      expect(!!valueChanges[address]).to.equal(true);
+    });
+
+    const signer1 = signers[1];
+    expect(valueChanges[signer1.address]).to.equal(undefined);
+  });
+
+  it("should order value changes in chronological order in each array", async () => {
+    const signers1to5 = signers.slice(1, 6);
+
+    // creates Transfer events in blocks 2-6
+    for (const signer of signers1to5) {
+      await tokenContract.mint(signer.address, parseEther("10"));
+    }
+    // creates Transfer events in blocks 7-12
+    for (const signer of signers1to5) {
+      await tokenContract.mint(signer.address, parseEther("10"));
+    }
+    // creates Transfer events in blocks 13-18
+    for (const signer of signers1to5) {
+      await tokenContract.mint(signer.address, parseEther("10"));
+    }
+
+    const startBlock = 2;
+    const endBlock = 18;
+    const valueChanges = await fetchValueChangesForERC20(
+      tokenContract.address,
+      startBlock,
+      endBlock,
+      provider,
+    );
+
+    expect(valueChanges[signer1.address]).to.deep.equal([
+      { valueChange: 10000000000000000000n, at: 2 },
+      { valueChange: 10000000000000000000n, at: 7 },
+      { valueChange: 10000000000000000000n, at: 12 },
+    ]);
+
+    expect(valueChanges[signer2.address]).to.deep.equal([
+      { valueChange: 10000000000000000000n, at: 3 },
+      { valueChange: 10000000000000000000n, at: 8 },
+      { valueChange: 10000000000000000000n, at: 13 },
+    ]);
+  });
+
+  it("should record negative values when tokens transferred between holders", async () => {
+    const signers1to5 = signers.slice(1, 6);
+
+    // creates Transfer events in blocks 2-6
+    for (const signer of signers1to5) {
+      await tokenContract.mint(signer.address, parseEther("10"));
+    }
+
+    // creates Transfer events in block 7
+    await tokenContract
+      .connect(signer1)
+      .transfer(signer2.address, parseEther("1"));
+
+    const startBlock = 2;
+    const endBlock = 7;
+    const valueChanges = await fetchValueChangesForERC20(
+      tokenContract.address,
+      startBlock,
+      endBlock,
+      provider,
+    );
+
+    // transfer to signer 2 in block 7 shows up as negative
+    expect(valueChanges[signer1.address]).to.deep.equal([
+      { valueChange: 10000000000000000000n, at: 2 },
+      { valueChange: -1000000000000000000n, at: 7 },
+    ]);
+
+    // transfer from signer 1 in block 7 shows up as positive
+    expect(valueChanges[signer2.address]).to.deep.equal([
+      { valueChange: 10000000000000000000n, at: 3 },
+      { valueChange: 1000000000000000000n, at: 7 },
+    ]);
+  });
+});
+
+export async function deployERC20(
+  signer: SignerWithAddress,
+): Promise<MockERC20> {
+  const tokenDeployer = new MockERC20__factory(signer);
+  const tokenContract = await tokenDeployer.deploy(
+    "Element Governance Token",
+    "ELFI",
+    signer.address,
+  );
+
+  return tokenContract;
+}

--- a/packages/council-sdk/src/fetchValueChangesForERC20.ts
+++ b/packages/council-sdk/src/fetchValueChangesForERC20.ts
@@ -1,0 +1,77 @@
+import { ERC20__factory } from "@elementfi/core-typechain/dist/libraries";
+import { Provider } from "@ethersproject/providers";
+import { constants } from "ethers";
+
+import { ValueChange } from "src/ValueChange";
+
+/**
+ * Fetches all transactions for an ERC20 and convets them to value changes over a block period.  A
+ * single transaction between accounts will create two value changes, a negative one for the sender
+ * and a positive one for the receiver.  Note that the zero address and the token address itself are
+ * ignored.
+ * @param balancesAtStartBlock An addressed keyed object of all holders of a token at the beginning
+ * of the period.
+ * @param tokenAddress Address of the token to fetch values for.
+ * @param startBlock Starting block (inclusive) to fetch value changes for.
+ * @param endBlock Ending block (inclusive) to fetch value changes for.  'latest' will fetch until
+ * the latest block.
+ * @param provider An ethereum node provider.
+ * @returns {Promise<Record<string, ValueChange[]>>} Returns an address keyed record of value
+ * changes of the block period.
+ */
+export async function fetchValueChangesForERC20(
+  tokenAddress: string,
+  startBlock: number,
+  endBlock: number | "latest",
+  provider: Provider,
+): Promise<Record<string, ValueChange[]>> {
+  const tokenContract = ERC20__factory.connect(tokenAddress, provider);
+  const transfersQueryFilter = tokenContract.filters.Transfer();
+
+  const results = await tokenContract.queryFilter(
+    transfersQueryFilter,
+    startBlock,
+    endBlock,
+  );
+
+  const resultsByAddress: Record<string, ValueChange[]> = {};
+
+  results.forEach((result) => {
+    const { args, blockNumber } = result;
+    if (!args) {
+      return;
+    }
+    const [from, to, value] = args;
+    const amount = BigInt(value.toString());
+    const valueChangeTo: ValueChange = { valueChange: amount, at: blockNumber };
+    const valueChangeFrom: ValueChange = {
+      // if an accounts transfer from, that subtracts from their balance.
+      valueChange: amount * BigInt("-1"),
+      at: blockNumber,
+    };
+
+    if (resultsByAddress[to]) {
+      resultsByAddress[to].push(valueChangeTo);
+    } else {
+      resultsByAddress[to] = [valueChangeTo];
+    }
+
+    if (resultsByAddress[from]) {
+      resultsByAddress[from].push(valueChangeFrom);
+    } else {
+      resultsByAddress[from] = [valueChangeFrom];
+    }
+
+    // we don't want to tally the zero address balance
+    if (resultsByAddress[constants.AddressZero]) {
+      delete resultsByAddress[constants.AddressZero];
+    }
+
+    // we also don't want to tally the token's own balance
+    if (resultsByAddress[tokenAddress]) {
+      delete resultsByAddress[tokenAddress];
+    }
+  });
+
+  return resultsByAddress;
+}

--- a/packages/council-sdk/src/test/mineBlocks.ts
+++ b/packages/council-sdk/src/test/mineBlocks.ts
@@ -1,0 +1,10 @@
+import { MockProvider } from "ethereum-waffle";
+
+export async function mineBlocks(
+  numBlocks: number,
+  provider: MockProvider,
+): Promise<void> {
+  for (let index = 0; index < numBlocks; index++) {
+    await provider.send("evm_mine", []);
+  }
+}

--- a/packages/council-sdk/src/test/snapshot.ts
+++ b/packages/council-sdk/src/test/snapshot.ts
@@ -1,0 +1,16 @@
+import { MockProvider } from "ethereum-waffle";
+
+const snapshotIdStack: number[] = [];
+export async function createSnapshot(provider: MockProvider): Promise<void> {
+  const id = await provider.send("evm_snapshot", []);
+  snapshotIdStack.push(id);
+}
+
+export async function restoreSnapshot(provider: MockProvider): Promise<void> {
+  const id = snapshotIdStack.pop();
+  try {
+    await provider.send("evm_revert", [id]);
+  } catch (ex) {
+    throw new Error(`Snapshot with id #${id} failed to revert`);
+  }
+}


### PR DESCRIPTION
Adds some methods to help with calculating rewards for holders of an ERC20.  This is a part of the effort for the OptimisticRewards contract where we want to independently verify token rewards across the frontends.  This gives benefit of decentralizing the verification.  An example is included for a simple time-weighted-average calculation.

- add function to calculate time weighted average
- add function to fetch value changes
- add function to convert to balances
- add test helpers
- add example to calculate rewards
- add fetcher for IPFS data
