### PR TITLE
Add eslint-plugin-tailwindcss config to individual repos

### DIFF
--- a/apps/council-frontend/.eslintrc
+++ b/apps/council-frontend/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": [
+    "plugin:tailwindcss/recommended",
     "@elementfi/eslint-config"
   ],
   "overrides": [

--- a/apps/council-frontend/package.json
+++ b/apps/council-frontend/package.json
@@ -45,6 +45,7 @@
     "d3-time-format": "^4.1.0",
     "date-fns": "^2.28.0",
     "eslint": "^7.32.0",
+    "eslint-plugin-tailwindcss": "^3.4.4",
     "env-cmd": "^10.1.0",
     "ethers": "^5.6.6",
     "graphql": "^15.8.0",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -7,7 +7,6 @@ module.exports = {
     "plugin:testing-library/react",
     "plugin:jest-dom/recommended",
     "plugin:jsx-a11y/recommended",
-    "plugin:tailwindcss/recommended",
     /**
      * Prettier must be the last extension in the list.
      * Prettier works best if you disable all other ESLint rules relating to


### PR DESCRIPTION
Removes extending `plugin:tailwindcss/recommended` from base as not all repos require it (packages, and nft-interface, and potentially any future apps).

Adds  `plugin:tailwindcss/recommended` to the only repo that currently has its own linting set up (council-frontend)