### PR TITLE
Pin tailwind version in core-frontend

### DIFF
--- a/apps/core-frontend/package.json
+++ b/apps/core-frontend/package.json
@@ -104,7 +104,7 @@
     "react-render-markup": "^3.4.0",
     "react-use": "^17.3.1",
     "source-map-explorer": "^2.5.2",
-    "tailwindcss": "^1.9.6",
+    "tailwindcss": "1.9.6",
     "tailwindcss-classnames": "^1.9.0",
     "ts-money": "^0.4.6",
     "ttag": "^1.7.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27980,7 +27980,7 @@ tailwindcss-classnames@^1.9.0:
     lodash "^4.17.15"
     tslib "^2.0.0"
 
-tailwindcss@^1.9.6:
+tailwindcss@1.9.6:
   version "1.9.6"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.9.6.tgz#0c5089911d24e1e98e592a31bfdb3d8f34ecf1a0"
   integrity sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==
@@ -32080,8 +32080,8 @@ zen-observable@0.8.15:
   version "1.0.2"
   resolved "https://codeload.github.com/a16z/zkp-merkle-airdrop-lib/tar.gz/c5e938fd167402c1b630c8f6c38553721ed0bfca"
   dependencies:
-    circomlibjs "0.0.8"
-    snarkjs "0.4.10"
+    circomlibjs "^0.0.8"
+    snarkjs "^0.4.10"
 
 zustand@^4.0.0-rc.1:
   version "4.0.0-rc.1"


### PR DESCRIPTION
We wont be upgrading core-frontend to the latest tailwind, since core-v2 is already under way..

Related to #199 