### PR TITLE
Add prettier config to vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,11 @@
     "semibold",
     "ttag",
     "unstake"
-  ]
+  ],
+  "prettier.tabWidth": 2,
+  "prettier.useTabs": false,
+  "prettier.trailingComma": "all",
+  "prettier.singleQuote": false,
+  "prettier.semi": true,
+  "prettier.printWidth": 80
 }


### PR DESCRIPTION
Adding prettier config to the workspace settings now that there are no .prettierrc files to control the "Format Document" command.