### PR TITLE
Add ignoreNoDocuments to graphql codegen config

### DIFF
--- a/packages/graphql/dist/codegen/generate.js
+++ b/packages/graphql/dist/codegen/generate.js
@@ -134,8 +134,6 @@ var __generator =
   };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generate = void 0;
-var load_1 = require("@graphql-tools/load");
-var graphql_file_loader_1 = require("@graphql-tools/graphql-file-loader");
 var cli_1 = require("@graphql-codegen/cli");
 var configs_js_1 = require("./configs.js");
 // https://www.graphql-code-generator.com/docs/advanced/programmatic-usage
@@ -160,63 +158,42 @@ function generate(_a) {
     isPackage = _a.package,
     schema = _a.schema;
   return __awaiter(this, void 0, void 0, function () {
-    var config, err_1, baseTypesPath;
+    var config, baseTypesPath;
     var _b, _c, _d;
     return __generator(this, function (_e) {
-      switch (_e.label) {
-        case 0:
-          config = {
-            schema: "./**/*.graphql",
-            overwrite: true,
-          };
-          _e.label = 1;
-        case 1:
-          _e.trys.push([1, 3, , 4]);
-          // this will fail if there are no documents (operations) found.
-          return [
-            4 /*yield*/,
-            (0, load_1.loadDocuments)("./**/*.graphql", {
-              loaders: [new graphql_file_loader_1.GraphQLFileLoader()],
+      config = {
+        schema: "./**/*.graphql",
+        documents: "./**/*.graphql",
+        ignoreNoDocuments: true,
+        overwrite: true,
+      };
+      if (isPackage) {
+        config.generates =
+          ((_b = {}),
+          (_b["".concat(outDir, "/module.d.ts")] =
+            configs_js_1.moduleDefinitions),
+          (_b["".concat(outDir, "/index.ts")] = configs_js_1.packageMain),
+          _b);
+      } else {
+        if (schema) {
+          config.schema =
+            ((_c = {}),
+            (_c[schema] = {
+              loader: "@elementfi/graphql/dist/codegen/schemaLoader",
             }),
-          ];
-        case 2:
-          // this will fail if there are no documents (operations) found.
-          _e.sent();
-          // if it doesn't fail, include the documents field
-          config.documents = "./**/*.graphql";
-          return [3 /*break*/, 4];
-        case 3:
-          err_1 = _e.sent();
-          return [3 /*break*/, 4];
-        case 4:
-          if (isPackage) {
-            config.generates =
-              ((_b = {}),
-              (_b["".concat(outDir, "/module.d.ts")] =
-                configs_js_1.moduleDefinitions),
-              (_b["".concat(outDir, "/index.ts")] = configs_js_1.packageMain),
-              _b);
-          } else {
-            if (schema) {
-              config.schema =
-                ((_c = {}),
-                (_c[schema] = {
-                  loader: "@elementfi/graphql/dist/codegen/schemaLoader",
-                }),
-                _c);
-            }
-            baseTypesPath = "".concat(outDir, "/graphql.d.ts");
-            config.generates =
-              ((_d = {}),
-              (_d["".concat(outDir, "/graphql-modules.d.ts")] =
-                configs_js_1.moduleDefinitions),
-              (_d[baseTypesPath] = configs_js_1.types),
-              (_d["."] = (0, configs_js_1.getCollocatedHooks)(baseTypesPath)),
-              _d);
-          }
-          (0, cli_1.generate)(config);
-          return [2 /*return*/];
+            _c);
+        }
+        baseTypesPath = "".concat(outDir, "/graphql.d.ts");
+        config.generates =
+          ((_d = {}),
+          (_d["".concat(outDir, "/graphql-modules.d.ts")] =
+            configs_js_1.moduleDefinitions),
+          (_d[baseTypesPath] = configs_js_1.types),
+          (_d["."] = (0, configs_js_1.getCollocatedHooks)(baseTypesPath)),
+          _d);
       }
+      (0, cli_1.generate)(config);
+      return [2 /*return*/];
     });
   });
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -49,8 +49,6 @@
     "@graphql-codegen/typescript-operations": "^2.4.0",
     "@graphql-codegen/typescript-react-apollo": "^3.2.14",
     "@graphql-codegen/typescript-resolvers": "^2.7.1",
-    "@graphql-tools/graphql-file-loader": "^7.3.15",
-    "@graphql-tools/load": "^7.5.14",
     "@graphql-tools/schema": "^8.3.13",
     "@graphql-yoga/node": "^2.13.2",
     "prettier": "2.6.2",

--- a/packages/graphql/src/codegen/generate.ts
+++ b/packages/graphql/src/codegen/generate.ts
@@ -1,5 +1,3 @@
-import { loadDocuments } from "@graphql-tools/load";
-import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { generate as graphqlCodegen } from "@graphql-codegen/cli";
 import type { Types } from "@graphql-codegen/plugin-helpers";
 import {
@@ -40,27 +38,10 @@ export async function generate({
 }: GenerateOptions): Promise<void> {
   const config: Partial<Types.Config> = {
     schema: "./**/*.graphql",
+    documents: "./**/*.graphql",
+    ignoreNoDocuments: true,
     overwrite: true,
   };
-
-  // TODO: Create a PR on the @graphql-codegen/cli repo to handle missing
-  // schemas and documents more gracefully so you're not forced to edit your
-  // config for each scenario. If it can't find a schema or document, it should
-  // probably just log a warning, but continue generating what it can. If I
-  // require the script to throw an error to prevent "broken" builds in a CI/CD
-  // pipeline, then maybe that behavior should have a separate config setting I
-  // can disable/enable.
-  try {
-    // this will fail if there are no documents (operations) found.
-    await loadDocuments("./**/*.graphql", {
-      loaders: [new GraphQLFileLoader()],
-    });
-    // if it doesn't fail, include the documents field
-    config.documents = "./**/*.graphql";
-  } catch (err) {
-    // If no operations are found, don't include the documents field since it
-    // would cause the codegen to fail.
-  }
 
   if (isPackage) {
     config.generates = {

--- a/packages/graphql/src/codegen/generate.ts
+++ b/packages/graphql/src/codegen/generate.ts
@@ -39,6 +39,8 @@ export async function generate({
   const config: Partial<Types.Config> = {
     schema: "./**/*.graphql",
     documents: "./**/*.graphql",
+    // documents are files with graphql operations (queries and mutations). This
+    // option prevents the codegen from throwing an error if none are found.
     ignoreNoDocuments: true,
     overwrite: true,
   };


### PR DESCRIPTION
The graphql codegen library used to break if the config included a path to GraphQL documents, but none existed (documents = files with queries/operations, schema = files with type definitions). To prevent this, I had to first try to load the documents in a try, catch and only add the documents path to the config if documents were loaded successfully:
https://github.com/element-fi/frontend-monorepo/blob/main/packages/graphql/src/codegen/generate.ts#L46-L63

In @graphql-codegen/cli@2.8.0, a new field ignoreNoDocuments was added for this reason. So we can remove the additional document loading code.