### PR TITLE
Deprecate packages/integrations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   "prettier.singleQuote": false,
   "prettier.semi": true,
   "prettier.printWidth": 80,
-  "eslint.workingDirectories": ["packages/council-tokenlist"]
+  "eslint.workingDirectories": [
+    "packages/council-tokenlist",
+    "packages/base"
+  ]
 }

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -1,0 +1,3 @@
+## Deprecated
+
+DEPRECATED: Umbrella package for integration code w/ 3rd parties.


### PR DESCRIPTION
This is not going to be added to, nor is it going to be used after v2. Safe to deprecate!