### PR TITLE
Don't overfetch queryVotePower and queryVotePowerView

### DIFF
--- a/apps/council-frontend/src/ui/voting/useVotingPowerForAccount.ts
+++ b/apps/council-frontend/src/ui/voting/useVotingPowerForAccount.ts
@@ -7,8 +7,7 @@ import { useVestingVaultVotingPower } from "src/ui/voting/useVestingVaultVotingP
 export function useVotingPowerForAccountAtLatestBlock(
   account: string | undefined | null,
 ): string {
-  const { data: latestBlockNumber } = useLatestBlockNumber();
-  return useVotingPowerForAccount(account, latestBlockNumber);
+  return useVotingPowerForAccount(account);
 }
 
 /**


### PR DESCRIPTION
Avoid overfetching queryVotePower and queryVotePowerView by making the latestBlock lookup happen inside the queryFunction. This has the effect of the latest vote power only being requested once. After a mutation, the entire querycache is marked stale so everything will work as expected.